### PR TITLE
Implicit eager-loading when querying with dot-notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "feathers-commons": "^0.8.4",
     "feathers-errors": "^2.0.1",
     "feathers-query-filters": "^2.0.0",
+    "lodash": "^4.17.4",
     "lodash.omit": "^4.3.0",
     "uberproto": "^1.1.2"
   },


### PR DESCRIPTION
### Summary

This PR adds the ability for dot-notation query syntax to implicitly eager-load associations.
 
Example:

```javascript
// Assume Person, Task, and Project models
// Task has an 'owner' belongsTo association
// Task has a 'project' belongsTo association
// Person hasMany 'tasks' association
// People service uses the Person model
people.find({ query: { 'tasks.project.name': 'Project A'}})
it('(People `tasks.project.name` nested eager loading query) should return one owner with one task matching to the project name "Project A"', () =>
        people.find({ query: { 'tasks.project.name': 'Project A'}})
          .then((res) => Promise.all([
            //console.log(res[0].tasks.length),
            //res.map((item) => console.log(item.name)),
            expect(res).to.exist.and.instanceOf(Array).and.lengthOf(1),
            expect(res[0].tasks).to.exist.and.instanceOf(Array).and.lengthOf(1),
            expect(res[0].tasks[0].description).to.equal('Do it'),
        ]))
);
```

See newly added test cases for details.