### PR TITLE
Disable count for find without pagination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - '8'
   - '6'
   - '4'
 env:

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ class Service {
     const { filters, query } = getFilter(params.query || {});
     const where = utils.getWhere(query);
     const order = utils.getOrder(filters.$sort);
-    console.log('filter', filters, 'query', query, 'params', params, 'paginate', paginate);
+
     const q = Object.assign({
       where,
       order,


### PR DESCRIPTION
### Summary

This PR changes find to use findAll instead of findAndCountAll if pagination is disabled, this improves find times for queries where only a small subset of a large dataset is requests.

This should increase query time for most DBMS because the count would have to iterate trough the whole dataset even thought the query can be satisfied when the first element is found.



### Example:

Query:
```
var find = {
  query: {
    $limit: 1,
    $pagination: false,
    $sort: {
      foo: -1
    },
    foo: 'bar'
  }
}
```

With a large dataset (500,000 docs) in postgres this query triggers two finds:
```
SELECT count(DISTINCT("data"."id")) AS "count" FROM "data" AS "ad_products" WHERE "data"."foo" = 'bar';
```
and
```
SELECT "id", "foo" FROM "data" AS "ad_products" WHERE "data"."foo" = 'bar' ORDER BY "data"."foo"  LIMIT 1;
```

The first query takes ~180.533ms and the second ~0.789ms, this means the unnecessary count increases the find time by a factor of 200.

Also related https://github.com/feathersjs/feathers/issues/657