### PR TITLE
Add option to not return modified entries for bulk updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - '8'
   - '6'
   - '4'
 env:

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ class Service {
     const { filters, query } = getFilter(params.query || {});
     const where = utils.getWhere(query);
     const order = utils.getOrder(filters.$sort);
-    console.log('filter', filters, 'query', query, 'params', params, 'paginate', paginate);
+
     const q = Object.assign({
       where,
       order,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -371,6 +371,12 @@ describe('Feathers Sequelize Service', () => {
         )
       );
 
+      it('patch() with $returning=false returns empty array', () =>
+        people.patch(_ids.David, {name: 'Sarah'}, {$returning: false}).then(response =>
+          expect(response).to.deep.equal([])
+        )
+      );
+
       it('update() returns a model instance', () =>
         people.update(_ids.David, _data.David).then(instance =>
           expect(instance instanceof Model).to.be.ok
@@ -380,6 +386,12 @@ describe('Feathers Sequelize Service', () => {
       it('remove() returns a model instance', () =>
         people.remove(_ids.David).then(instance =>
           expect(instance instanceof Model).to.be.ok
+        )
+      );
+
+      it('remove() with $returning=false returns empty array', () =>
+        people.remove(_ids.David, {$returning: false}).then(response =>
+          expect(response).to.deep.equal([])
         )
       );
     });


### PR DESCRIPTION
### Summary

This is a reopening of https://github.com/feathersjs-ecosystem/feathers-sequelize/pull/117

This pull request is for a new way to omit the result of mass change operations like patch and remove.

This change requires discussion and adaption by all other adapters, the issue this tries to solve does affect people writing large apis with massive amounts of data.

In our case node crashed when updates affected several hundred thousand documents.
While the patch went through on the database, node reached its heap limit when receiving/retrieving the changed docs and crashed before answering the request.