### PR TITLE
Fixed handling of generic database errors, fixed nested NotFound for GET

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,11 @@ class Service {
     })
     .then(select(params, this.id))
     .catch(error => {
-      throw new errors.NotFound(`No record found for id '${id}'`, error);
+      if (error instanceof errors.NotFound) {
+        throw error;
+      }
+
+      utils.errorHandler(error);
     });
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,7 @@ exports.errorHandler = function errorHandler (error) {
       case 'SequelizeExclusionConstraintError':
       case 'SequelizeForeignKeyConstraintError':
       case 'SequelizeInvalidConnectionError':
+      case 'SequelizeDatabaseError':
         feathersError = new errors.BadRequest(error);
         break;
       case 'SequelizeTimeoutError':


### PR DESCRIPTION
### Summary

This PR fixes two problems:

- nesting NotFound exception
- passing whole sequelize stacktrace down to clients

The first problem manifests itself by nesting 404 errors - the response is 404 and the data contains the same error:

```json
{
    "name": "NotFound",
    "message": "No record found for id '4123123'",
    "code": 404,
    "className": "not-found",
    "data": {
        "name": "NotFound",
        "message": "No record found for id '4123123'",
        "code": 404,
        "className": "not-found"
    },
    "errors": {}
}
```

The second one triggers on database errors like data type conversion (i.e. string to integer like in my scenario). As a result final response sent to the client contains sensitive information from which it's easy to guess db vendor and db structure. Also, I think it's better to send 400 instead of 404 in case of malicious input.

```json
{
    "name": "NotFound",
    "message": "No record found for id '4123123sdfsdfdf'",
    "code": 404,
    "className": "not-found",
    "data": {
        "name": "SequelizeDatabaseError",
        "parent": {
            "name": "error",
            "length": 110,
            "severity": "ERROR",
            "code": "22P02",
            "position": "105",
            "file": "numutils.c",
            "line": "106",
            "routine": "pg_atoi",
            "sql": "SELECT \"id\", \"email\", \"password\", \"createdAt\", \"updatedAt\" FROM \"users\" AS \"users\" WHERE \"users\".\"id\" = '4123123sdfsdfdf';"
        },
        "original": {
            "name": "error",
            "length": 110,
            "severity": "ERROR",
            "code": "22P02",
            "position": "105",
            "file": "numutils.c",
            "line": "106",
            "routine": "pg_atoi",
            "sql": "SELECT \"id\", \"email\", \"password\", \"createdAt\", \"updatedAt\" FROM \"users\" AS \"users\" WHERE \"users\".\"id\" = '4123123sdfsdfdf';"
        },
        "sql": "SELECT \"id\", \"email\", \"password\", \"createdAt\", \"updatedAt\" FROM \"users\" AS \"users\" WHERE \"users\".\"id\" = '4123123sdfsdfdf';"
    },
    "errors": {}
}
```

After applying this PR, the responses are as follows:

```json
{
    "name": "NotFound",
    "message": "No record found for id '4123123'",
    "code": 404,
    "className": "not-found",
    "errors": {}
}
```

and

```json
{
    "name": "BadRequest",
    "message": "invalid input syntax for integer: \"4123123sdfsffsf\"",
    "code": 400,
    "className": "bad-request",
    "errors": {}
}
```
