### PR TITLE
Add replication support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import filter from 'feathers-query-filters';
 import errors from 'feathers-errors';
 import { select } from 'feathers-commons';
 import * as utils from './utils';
+import { Op } from 'sequelize';
 
 class Service {
   constructor (options) {
@@ -213,7 +214,7 @@ class Service {
         // Create a new query that re-queries all ids that
         // were originally changed
         const findParams = Object.assign({}, params, {
-          query: { [this.id]: { $in: idList } }
+          query: { [this.id]: { [Op.in]: idList } }
         });
 
         return Model.update(omit(data, this.id), options)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import errors from 'feathers-errors';
+import { Op } from 'sequelize';
 
 export function errorHandler (error) {
   let feathersError = error;
@@ -53,7 +54,7 @@ export function getWhere (query) {
     if (value && value.$nin) {
       value = Object.assign({}, value);
 
-      value.$notIn = value.$nin;
+      value[Op.notIn] = value.$nin;
       delete value.$nin;
 
       where[prop] = value;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import errors from 'feathers-errors';
 import * as utils from '../src/utils';
-import Sequelize from 'sequelize';
+import Sequelize, { Op } from 'sequelize';
 
 describe('Feathers Sequelize Utils', () => {
   describe('errorHandler', () => {
@@ -120,15 +120,15 @@ describe('Feathers Sequelize Utils', () => {
     });
 
     it('returns where conditions properly converted', () => {
-      let where = utils.getWhere({ name: 'Joe', age: { $lte: 25 } });
+      let where = utils.getWhere({ name: 'Joe', age: { [Op.lte]: 25 } });
 
-      expect(where).to.deep.equal({ name: 'Joe', age: { $lte: 25 } });
+      expect(where).to.deep.equal({ name: 'Joe', age: { [Op.lte]: 25 } });
     });
 
     it('converts $nin to $notIn', () => {
       let where = utils.getWhere({ name: { $nin: ['Joe', 'Alice'] } });
 
-      expect(where).to.deep.equal({ name: { $notIn: ['Joe', 'Alice'] } });
+      expect(where).to.deep.equal({ name: { [Op.notIn]: ['Joe', 'Alice'] } });
     });
   });
 });


### PR DESCRIPTION
As discussed on #174, this pull request adds support for basic master/replica setups.

This is _still a Work in Progress_, since there are some issues @DesignByOnyx would like me to address:

- [ ] don't make options.master required. If people are using replica sets, they will set it.
- [ ] allow more control in decideServer - right now you use random, but we should consider others like round-robin, sticky?, etc.
- [ ] ...TBD

## Some context
- We're using this in production in a setup with several geographically distributed replicas, primarily to reduce the latency of read operations, (but also to balance the load across multiple DB servers in the same region) So far it has held up reasonably well 😉
- [My original fork](https://github.com/coreh/feathers-sequelize-replicated) was not a "real" fork in GitHub terms and was kinda out of date with the master branch, so forked via the web interface and updated the code to be based on the latest `master`, in order to open this pull request. I expect it to be working fine, but I haven't properly tested it yet. (I'll test it in our staging environment)
- Commit 440b6c29156c936e3ba0f8b8077666c94563cdc8 is unrelated to the main goal of this PR, and is a fix for Sequelize v4, since [string operators are now deprecated in favor of symbol operators](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-security) (to avoid query injection attacks). It's a super minor change and I can open a separate PR for that if you'd like.
- Commit f14a84a5e1b24e58e2a8963ec7be4dbf65b609da adds a different `patch()` codepath, triggered whenever an `id` is specified, to work around the fact that Sequelize is unable to properly update nested Postgres JSONB fields via `Model.update()`. It's a kinda ugly hack and might not be useful for everyone, so I can either omit it, open a separate PR or keep it, at your discretion.
- Commit 3d2ed076b6dceea83130c6d4580866cf42457b23 is the real "meat" of this PR, and adds the actual master/replica routing logic.
- Right now the user of the API is responsible for creating all the master/replica Sequelize instances along with all the models — which must match exactly across all provided Sequelize instances.
- We're not handling replicas going offline. It might be a good idea to remove them from the pool and to add failover master support, making this also suitable for high availability