### PR TITLE
Support params.query in update()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -230,6 +230,7 @@ class Service {
   }
 
   update (id, data, params) {
+    const where = Object.assign({}, filterQuery(params.query || {}).query);
     const options = Object.assign({ raw: this.raw }, params.sequelize);
 
     if (Array.isArray(data)) {
@@ -239,7 +240,7 @@ class Service {
     // Force the {raw: false} option as the instance is needed to properly
     // update
 
-    return this._get(id, { sequelize: { raw: false } }).then(instance => {
+    return this._get(id, { sequelize: { raw: false } },{query: where}).then(instance => {
       if (!instance) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,10 +118,10 @@ class Service {
 
       return result[0];
     })
-    .then(select(params, this.id))
-    .catch(error => {
-      throw new errors.NotFound(`No record found for id '${id}'`, error);
-    });
+      .then(select(params, this.id))
+      .catch(error => {
+        throw new errors.NotFound(`No record found for id '${id}'`, error);
+      });
   }
 
   // returns either the model intance for an id or all unpaginated
@@ -187,26 +187,26 @@ class Service {
 
       return this._getOrFind(id, params)
         .then(results => this.getModel(params).update(omit(data, this.id), options))
-          .then(results => {
-            if (id === null) {
-              return results[1];
-            }
+        .then(results => {
+          if (id === null) {
+            return results[1];
+          }
 
-            if (!results[1].length) {
-              throw new errors.NotFound(`No record found for id '${id}'`);
-            }
+          if (!results[1].length) {
+            throw new errors.NotFound(`No record found for id '${id}'`);
+          }
 
-            return results[1][0];
-          })
-          .then(select(params, this.id))
-          .catch(utils.errorHandler);
+          return results[1][0];
+        })
+        .then(select(params, this.id))
+        .catch(utils.errorHandler);
     }
 
     // By default we will just query for the one id. For multi patch
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
     const ids = id === null ? this._find(params)
-        .then(mapIds) : Promise.resolve([ id ]);
+      .then(mapIds) : Promise.resolve([ id ]);
 
     return ids
       .then(idList => {
@@ -217,13 +217,13 @@ class Service {
         });
 
         return Model.update(omit(data, this.id), options)
-            .then(() => {
-              if (params.$returning !== false) {
-                return this._getOrFind(id, findParams);
-              } else {
-                return Promise.resolve([]);
-              }
-            });
+          .then(() => {
+            if (params.$returning !== false) {
+              return this._getOrFind(id, findParams);
+            } else {
+              return Promise.resolve([]);
+            }
+          });
       })
       .then(select(params, this.id))
       .catch(utils.errorHandler);
@@ -240,7 +240,7 @@ class Service {
     // Force the {raw: false} option as the instance is needed to properly
     // update
 
-    return this._get(id, { sequelize: { raw: false } },{query: where}).then(instance => {
+    return this._get(id, { sequelize: { raw: false }, query: where }).then(instance => {
       if (!instance) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }
@@ -256,8 +256,8 @@ class Service {
 
       return instance.update(copy, {raw: false}).then(() => this._get(id, {sequelize: options}));
     })
-    .then(select(params, this.id))
-    .catch(utils.errorHandler);
+      .then(select(params, this.id))
+      .catch(utils.errorHandler);
   }
 
   remove (id, params) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -201,8 +201,8 @@ describe('Feathers Sequelize Service', () => {
             assert.equal(people.data[0].name, name);
             assert.equal(people.data[0].age, null);
           })
-          .then(() => people.remove(person.id))
-          .catch((err) => { people.remove(person.id); throw (err); })
+            .then(() => people.remove(person.id))
+            .catch((err) => { people.remove(person.id); throw (err); })
         );
       });
 
@@ -210,10 +210,28 @@ describe('Feathers Sequelize Service', () => {
         const updateName = 'Ryan';
 
         return people.update(_ids.Kirsten, { name: updateName })
-            .then((data) => people.get(_ids.Kirsten))
-            .then(updatedPerson => {
-              assert.equal(updatedPerson.name, updateName);
-            });
+          .then((data) => people.get(_ids.Kirsten))
+          .then(updatedPerson => {
+            assert.equal(updatedPerson.name, updateName);
+          });
+      });
+
+      it('corrently updates records using optional query param', () => {
+        const updateAge = 40;
+        const updateName = 'Kirtsten';
+        return people.update(_ids.Kirsten, { name: updateName, age: updateAge }, {query: {name: 'Kirsten'}})
+          .then((data) => people.get(_ids.Kirsten))
+          .then(updatedPerson => {
+            assert.equal(updatedPerson.age, updateAge);
+          });
+      });
+
+      it('fails update when query prevents result in no record match for id', () => {
+        const updateAge = 50;
+        const updateName = 'Kirtsten';
+        return people.update(_ids.Kirsten, { name: updateName, age: updateAge }, {query: {name: 'John'}})
+          .then((data) => assert(false, 'Should have thrown an error'))
+          .catch(err => assert(err.message.indexOf('No record found') >= 0));
       });
     });
 
@@ -225,25 +243,25 @@ describe('Feathers Sequelize Service', () => {
 
       beforeEach(() =>
         people.create({ name: 'Kirsten', age: 30 })
-        .then(result => {
-          _data.Kirsten = result;
-          _ids.Kirsten = result.id;
-          return orders.create([
-            { name: 'Order 1', personId: result.id },
-            { name: 'Order 2', personId: result.id },
-            { name: 'Order 3', personId: result.id }
-          ]);
-        })
-        .then(() => people.create({ name: 'Ryan', age: 30 }))
-        .then(result => {
-          _data.Ryan = result;
-          _ids.Ryan = result.id;
-          return orders.create([
-            { name: 'Order 4', personId: result.id },
-            { name: 'Order 5', personId: result.id },
-            { name: 'Order 6', personId: result.id }
-          ]);
-        })
+          .then(result => {
+            _data.Kirsten = result;
+            _ids.Kirsten = result.id;
+            return orders.create([
+              { name: 'Order 1', personId: result.id },
+              { name: 'Order 2', personId: result.id },
+              { name: 'Order 3', personId: result.id }
+            ]);
+          })
+          .then(() => people.create({ name: 'Ryan', age: 30 }))
+          .then(result => {
+            _data.Ryan = result;
+            _ids.Ryan = result.id;
+            return orders.create([
+              { name: 'Order 4', personId: result.id },
+              { name: 'Order 5', personId: result.id },
+              { name: 'Order 6', personId: result.id }
+            ]);
+          })
       );
 
       afterEach(() =>
@@ -304,8 +322,8 @@ describe('Feathers Sequelize Service', () => {
             assert.equal(result.data.length, 0);
           });
         })
-        .then(() => people.remove(person.id))
-        .catch((err) => { people.remove(person.id); throw (err); });
+          .then(() => people.remove(person.id))
+          .catch((err) => { people.remove(person.id); throw (err); });
       });
     });
   });


### PR DESCRIPTION
I have permissions hooks that add fields to params.query for all service operations to limit records that can be updated/retrieved to a filtered set by 'owner_id'.

update() is the only method that doesn't support params.query to augment the final query.

I understand why, since it is only supposed to act on a specific record by id, which should always be unique.

If you don't accept the PR I understand.

In the meantime I've created a custom Service class extended from the sequelize Service class and overridden update()

Also want to avoid doing a hook that has to query for the record first to do the check before an update, to avoid a double query.

I may implement feathers-cache at some point, but don't know how robust that is yet in scaling and multiple server instances.



