### PR TITLE
Add the explicit call to setup() to initialize relations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ Creat a temporary file in your project root like this:
 ```js
 // test.js
 const app = require('./src/app');
+// run setup to initialize relations
+app.setup();
 const seqClient = app.get('sequelizeClient');
 const SomeModel = seqClient.models['some-model'];
 const log = console.log.bind(console);


### PR DESCRIPTION
When using the test script, if you do not call `setup()`, then the (cli-generated service model) code 

```
{model}.associate = function(models) {...}
```

never gets called and associations are never defined.