### PR TITLE
Added full support for composite primary keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ class Service {
     this.options = options;
     this.Model = options.Model;
     this.id = options.id || 'id';
+    this.idSeparator = options.idSeparator || ',';
     this.events = options.events;
     this.raw = options.raw !== false;
   }
@@ -39,7 +40,15 @@ class Service {
   }
 
   extractIdsFromString (id) {
-    return id[0] === '[' && id[id.length - 1] === ']' ? JSON.parse(id) : id.split(',');
+    if (id[0] === '[' && id[id.length - 1] === ']') {
+      return JSON.parse(id);
+    }
+
+    if (id[0] === '{' && id[id.length - 1] === '}') {
+      return Object.values(JSON.parse(id));
+    }
+
+    return id.split(this.idSeparator);
   }
 
   // Create a new query that re-queries all ids that were originally changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,14 +39,10 @@ class Service {
     return Proto.extend(obj, this);
   }
 
-  extractIdsFromString (id) {
-    if (id[0] === '[' && id[id.length - 1] === ']') {
-      return JSON.parse(id);
-    }
-
-    if (id[0] === '{' && id[id.length - 1] === '}') {
-      return Object.values(JSON.parse(id));
-    }
+  extractIds (id) {
+    if (typeof id === 'object') { return Object.values(id); }
+    if (id[0] === '[' && id[id.length - 1] === ']') { return JSON.parse(id); }
+    if (id[0] === '{' && id[id.length - 1] === '}') { return Object.values(JSON.parse(id)); }
 
     return id.split(this.idSeparator);
   }
@@ -59,7 +55,7 @@ class Service {
       let ids = id;
 
       if (id !== null && !Array.isArray(id)) {
-        ids = this.extractIdsFromString(id.toString());
+        ids = this.extractIds(id);
       }
 
       this.id.forEach((idKey, index) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,14 +213,14 @@ class Service {
   }
 
   patch (id, data, params) {
-    const where = Object.assign({}, filterQuery(params.query || {}).query);
+    let where = Object.assign({}, filterQuery(params.query || {}).query);
     const mapIds = page => Array.isArray(this.id)
       ? this.id.map(idKey => [...new Set(page.data.map(current => current[idKey]))])
       : page.data.map(current => current[this.id]);
 
     if (id !== null) {
       if (Array.isArray(this.id)) {
-        Object.entries(this.getIdsQuery(id)).forEach(entry => { where[entry[0]] = entry[1]; });
+        where = Object.assign({}, where, this.getIdsQuery(id));
       } else {
         where[this.id] = id;
       }
@@ -307,11 +307,11 @@ class Service {
 
   remove (id, params) {
     const opts = Object.assign({ raw: this.raw }, params);
-    const where = Object.assign({}, filterQuery(params.query || {}).query);
+    let where = Object.assign({}, filterQuery(params.query || {}).query);
 
     if (id !== null) {
       if (Array.isArray(this.id)) {
-        Object.entries(this.getIdsQuery(id)).forEach(entry => { where[entry[0]] = entry[1]; });
+        where = Object.assign({}, where, this.getIdsQuery(id));
       } else {
         where[this.id] = id;
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ class Service {
     if (!options.Model) {
       throw new Error('You must provide a Sequelize Model');
     }
-    
+
     this.paginate = options.paginate || false;
     this.options = options;
     this.Model = options.Model;
@@ -36,6 +36,43 @@ class Service {
 
   extend (obj) {
     return Proto.extend(obj, this);
+  }
+
+  extractIdsFromString (id) {
+    return id[0] === '[' && id[id.length - 1] === ']' ? JSON.parse(id) : id.split(',');
+  }
+
+  // Create a new query that re-queries all ids that were originally changed
+  getIdsQuery (id, idList) {
+    const query = {};
+
+    if (Array.isArray(this.id)) {
+      let ids = id;
+
+      if (id !== null && !Array.isArray(id)) {
+        ids = this.extractIdsFromString(id.toString());
+      }
+
+      this.id.forEach((idKey, index) => {
+        if (ids === null) {
+          if (idList) {
+            if (idList[index]) {
+              query[idKey] = { $in: idList[index] };
+            }
+          } else {
+            query[idKey] = null;
+          }
+        } else if (ids[index]) {
+          query[idKey] = ids[index];
+        } else {
+          throw new errors.BadRequest('When using composite primary key, id must contain values for all primary keys');
+        }
+      });
+    } else {
+      query[this.id] = idList ? { $in: idList } : id;
+    }
+
+    return query;
   }
 
   _find (params, getFilter = filterQuery, paginate) {
@@ -105,7 +142,7 @@ class Service {
     // Attach 'where' constraints, if any were used.
     const q = Object.assign({
       raw: this.raw,
-      where: Object.assign({[this.id]: id}, where)
+      where: Object.assign({}, Array.isArray(this.id) ? this.getIdsQuery(id) : {[this.id]: id}, where)
     }, params.sequelize);
 
     let Model = this.applyScope(params);
@@ -172,10 +209,16 @@ class Service {
 
   patch (id, data, params) {
     const where = Object.assign({}, filterQuery(params.query || {}).query);
-    const mapIds = page => page.data.map(current => current[this.id]);
+    const mapIds = page => Array.isArray(this.id)
+      ? this.id.map(idKey => [...new Set(page.data.map(current => current[idKey]))])
+      : page.data.map(current => current[this.id]);
 
     if (id !== null) {
-      where[this.id] = id;
+      if (Array.isArray(this.id)) {
+        Object.entries(this.getIdsQuery(id)).forEach(entry => { where[entry[0]] = entry[1]; });
+      } else {
+        where[this.id] = id;
+      }
     }
 
     const options = Object.assign({raw: this.raw}, params.sequelize, { where });
@@ -211,11 +254,7 @@ class Service {
 
     return ids
       .then(idList => {
-        // Create a new query that re-queries all ids that
-        // were originally changed
-        const findParams = Object.assign({}, params, {
-          query: { [this.id]: { $in: idList } }
-        });
+        const findParams = Object.assign({}, params, { query: this.getIdsQuery(id, idList) });
 
         return Model.update(omit(data, this.id), options)
           .then(() => {
@@ -266,7 +305,11 @@ class Service {
     const where = Object.assign({}, filterQuery(params.query || {}).query);
 
     if (id !== null) {
-      where[this.id] = id;
+      if (Array.isArray(this.id)) {
+        Object.entries(this.getIdsQuery(id)).forEach(entry => { where[entry[0]] = entry[1]; });
+      } else {
+        where[this.id] = id;
+      }
     }
 
     const options = Object.assign({}, params.sequelize, { where });

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ class Service {
   }
 
   extractIds (id) {
-    if (typeof id === 'object') { return Object.values(id); }
+    if (typeof id === 'object') { return this.id.map(idKey => id[idKey]); }
     if (id[0] === '[' && id[id.length - 1] === ']') { return JSON.parse(id); }
     if (id[0] === '{' && id[id.length - 1] === '}') { return Object.values(JSON.parse(id)); }
 


### PR DESCRIPTION
When using DB tables with composite primary keys, there is no way to use the `id` argument to match or fail against a single unique record.

This PR adds support for composite primary keys by enabling a developer to set the `service.id` property to an array of strings and use the `id` argument to pass all composite keys' values of a record.

When calling a service method with the `id` argument, all primary keys are required to be passed if using composite primary keys.

Composite `id` values can be passed as:

- string with values separated by the new `service.idSeparator` property or using the default comma separator (order matter, recommended for REST)
- JSON array (order matter, recommended for internal service calls)
- JSON object (more readable, recommended for internal service calls)