### PR TITLE
Fixed issue where params are ignored on update service calls.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -241,7 +241,7 @@ class Service {
     // Force the {raw: false} option as the instance is needed to properly
     // update
 
-    return this._get(id, { sequelize: { raw: false }, query: where }).then(instance => {
+    return this._get(id, { ...params, sequelize: { raw: false }, query: where }).then(instance => {
       if (!instance) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }
@@ -255,7 +255,7 @@ class Service {
         }
       });
 
-      return instance.update(copy, {raw: false}).then(() => this._get(id, {sequelize: options}));
+      return instance.update(copy, {...params, raw: false}).then(() => this._get(id, {...params, sequelize: options}));
     })
       .then(select(params, this.id))
       .catch(utils.errorHandler);


### PR DESCRIPTION
This is a resolution for issue #234. I will paste the content of the issue report below:

Take a look at these two lines:
https://github.com/feathersjs-ecosystem/feathers-sequelize/blob/6f5c5474a1446cc0218168736db33f20d5c7cab3/lib/index.js#L244
https://github.com/feathersjs-ecosystem/feathers-sequelize/blob/6f5c5474a1446cc0218168736db33f20d5c7cab3/lib/index.js#L258

Lines like these do overrides such as `raw: false`, which is totally fine, but in the process they also fail to pass through the other attributes of the  `params` object that was provided by the original caller of the service method (further up the callstack).

When a service call is made by some featherjs user's code, it's important to preserve the `params` object when making any subsequent service calls, as it's possible that the user of feathersjs intends to use these parameters as part of a `getModel()` override function in a custom service class (i.e. `class MySpecialService extends Service` with an overidden `getModel()`) For things like multi-tenancy schemes (hosting multiple domains/sites out of a single app instance such that each site needs to hit a different database).

Any practice of ignoring/clobbering the params passed in will cause problems for such a scheme.

For the most part I have not noticed an issue with this -- As far as I know, get, find, and most other service calls do not have this practice of completely overriding the params with their own value, but update does have this issue. I will submit a pull request for this.