### PR TITLE
use transactions in `update`, related to #188

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,7 @@ class Service {
     // update
     const updateOptions = Object.assign({ raw: false }, params.sequelize);
 
-    return this._get(id, { sequelize: updateOptions, query: where }).then(instance => {
+    return this._get(id, { sequelize: { raw: false }, query: where }).then(instance => {
       if (!instance) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -240,8 +240,9 @@ class Service {
 
     // Force the {raw: false} option as the instance is needed to properly
     // update
+    const updateOptions = Object.assign({ raw: false }, params.sequelize);
 
-    return this._get(id, { sequelize: { raw: false }, query: where }).then(instance => {
+    return this._get(id, { sequelize: updateOptions, query: where }).then(instance => {
       if (!instance) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }
@@ -255,7 +256,7 @@ class Service {
         }
       });
 
-      return instance.update(copy, {raw: false}).then(() => this._get(id, {sequelize: options}));
+      return instance.update(copy, updateOptions).then(() => this._get(id, {sequelize: options}));
     })
       .then(select(params, this.id))
       .catch(utils.errorHandler);


### PR DESCRIPTION
### Use transactions in `update`, related to #188

As mentioned in #188, the update method has no transaction support.
This simple PR adds transaction support to calls to `update`.