### PR TITLE
Fix in get request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,8 @@ class Service {
     // Attach 'where' constraints, if any were used.
     const q = Object.assign({
       raw: this.raw,
-      where: Object.assign({[this.id]: id}, where)
+      where: Object.assign({[this.id]: id}, where),
+      order: []
     }, params.sequelize);
 
     let Model = this.applyScope(params);


### PR DESCRIPTION
When we try to get data of a paricular id (i.e) http://domain.com/service/:id, we receive 404 not found error saying, no record found for id 'xxxxx' but the same returns me the actual data when I construct the url as http://domain.com/service?id=xxxxx

I found that adding **order: []** to the query parameter in the _get function gets me the actual data.

Not sure what exactly happens in the background.

Please add your comments for more clarification and details