### PR TITLE
Fixed issue where params are ignored on update service calls.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -240,9 +240,10 @@ class Service {
 
     // Force the {raw: false} option as the instance is needed to properly
     // update
-    const updateOptions = Object.assign({ raw: false }, params.sequelize);
+    const updateOptions = Object.assign({}, params.sequelize, { raw: false });
+    const getOptions = Object.assign({}, params, { query: where, sequelize: { raw: false } });
 
-    return this._get(id, { sequelize: { raw: false }, query: where }).then(instance => {
+    return this._get(id, getOptions).then(instance => {
       if (!instance) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }


### PR DESCRIPTION
This is another attempt at a resolution for issue #234. I will paste the content of the issue report below:

Take a look at these two lines:
https://github.com/feathersjs-ecosystem/feathers-sequelize/blob/master/lib/index.js#L245
https://github.com/feathersjs-ecosystem/feathers-sequelize/blob/master/lib/index.js#L259

Lines like these do overrides such as `raw: false`, which is totally fine, but in the process they also fail to pass through the other attributes of the  `params` object that was provided by the original caller of the service method (further up the callstack).

When a service call is made by some featherjs user's code, it's important to preserve the `params` object when making any subsequent service calls, as it's possible that the user of feathersjs intends to use these parameters as part of a `getModel()` override function in a custom service class (i.e. `class MySpecialService extends Service` with an overidden `getModel()`) For things like multi-tenancy schemes (hosting multiple domains/sites out of a single app instance such that each site needs to hit a different database).

Any practice of ignoring/clobbering the params passed in will cause problems for such a scheme.

For the most part I have not noticed an issue with this -- As far as I know, get, find, and most other service calls do not have this practice of completely overriding the params with their own value, but update does have this issue. I will submit a pull request for this.