### PR TITLE
Convert all Sequelize errors into a safe FeathersError

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@ exports.ERROR = ERROR;
 exports.errorHandler = error => {
   const { name, message } = error;
 
-  if (name) {
+  if (name.startsWith('Sequelize')) {
     switch (name) {
       case 'SequelizeValidationError':
       case 'SequelizeUniqueConstraintError':
@@ -24,7 +24,10 @@ exports.errorHandler = error => {
       case 'SequelizeHostNotReachableError':
         throw wrap(new errors.Unavailable(message), error);
       case 'SequelizeHostNotFoundError':
+      case 'SequelizeDatabaseError':
         throw wrap(new errors.NotFound(message), error);
+      default:
+        throw wrap(new errors.GeneralError(message), error);
     }
   }
 


### PR DESCRIPTION
Because we never really want to expose database information to the outside.