### PR TITLE
Add service.Model back

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,6 @@ The following breaking changes have been introduced:
 
 - All methods now take `params.sequelize` into account
 - All methods allow additional query parameters
-- `this.Model` has been remove. Use `this.getModel()` instead.
 - Multiple updates are disabled by default (see the `multi` option)
 - Upgraded to secure Sequelize operators (see the [operators](#operators) option)
 - Errors no longer contain Sequelize specific information. The original Sequelize error can be retrieved on the server via:

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,10 @@ class Service extends AdapterService {
     this.raw = options.raw !== false;
   }
 
+  get Model () {
+    return this.getModel();
+  }
+
   getModel (params) {
     return this.options.Model;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -185,6 +185,10 @@ describe('Feathers Sequelize Service', () => {
         id: 'customid'
       }));
 
+    it('has .Model', () => {
+      assert.ok(app.service('people').Model);
+    });
+
     testSuite(app, errors, 'people', 'id');
     testSuite(app, errors, 'people-customid', 'customid');
   });


### PR DESCRIPTION
Because all the other db adapters do have it, too.