### PR TITLE
Added getModel override param passing tests and fixes (still some failures, help wanted)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -260,18 +260,17 @@ class Service extends AdapterService {
 
     // Force the {raw: false} option as the instance is needed to properly
     // update
-    const updateOptions = Object.assign({}, params.sequelize, { raw: false });
-    const getOptions = Object.assign({}, params, { query: where, sequelize: { raw: false } });
+    const seqOptions = Object.assign({}, params.sequelize, { raw: false });
 
-    return this._get(id, getOptions).then(instance => {
+    return this._get(id, { sequelize: seqOptions, query: where }).then(instance => {
       const copy = Object.keys(instance.toJSON()).reduce((result, key) => {
         result[key] = typeof data[key] === 'undefined' ? null : data[key];
 
         return result;
       }, {});
 
-      return instance.update(copy, updateOptions)
-        .then(() => this._get(id, { sequelize: params.sequelize }));
+      return instance.update(copy, seqOptions)
+        .then(() => this._get(id, { sequelize: seqOptions }));
     })
       .then(select(params, this.id))
       .catch(utils.errorHandler);


### PR DESCRIPTION
This adds a set of service tests that ensure that all params.sequelize attributes are passed all the way down through to the getModel() of any service calls (and also to any subsequent service calls made by those service calls). This is important for reasons already outlined in #234 but I will paste the relevant section here:

> When a service call is made by some featherjs user's code, it's important to preserve the sequelize member of the params object when making any subsequent service calls, as it's possible that the user of feathersjs intends to use these parameters as part of a getModel() override function in a custom service class (i.e. class MySpecialService extends Service with an overidden getModel()) For things like multi-tenancy schemes - hosting multiple domains/sites out of a single app instance such that each site needs to hit a different database. As far as I'm aware, a getModel() override is the best way of achieving that goal, and any practice of ignoring/clobbering the params.sequelize passed in will cause problems for such a scheme.

It would be nice to have some tests in place to prevent regressions related to this functionality in the future, so that's why I've prepared these commits. Commit abcce1b adds the tests, and commit 8a95fec fixes a couple of test failures.

However: There are still two test failures that indicate that params.sequelize is not being passed fully down the chain. Here are traces for these test failures:
```
  1) Feathers Sequelize Service
       ORM functionality with overidden getModel method
         Non-raw Service Method Calls
           `raw: false` works for create():
     Error: Expected custom attribute not found in overridden getModel()!
      at Object.getModel (test/index.test.js:552:17)
      at Object.applyScope (lib/index.js:55:17)
      at Object._remove (lib/index.js:289:22)
      at callMethod (node_modules/@feathersjs/adapter-commons/lib/service.js:9:20)
      at Object.remove (node_modules/@feathersjs/adapter-commons/lib/service.js:90:12)
      at processHooks.call.then.hookObject (node_modules/@feathersjs/feathers/lib/hooks/index.js:56:27)

  2) Feathers Sequelize Service
       ORM functionality with overidden getModel method
         Non-raw Service Method Calls
           `raw: false` works for bulk create():
     Error: Expected custom attribute not found in overridden getModel()!
      at Object.getModel (test/index.test.js:552:17)
      at Object.applyScope (lib/index.js:55:17)
      at Object._remove (lib/index.js:289:22)
      at callMethod (node_modules/@feathersjs/adapter-commons/lib/service.js:9:20)
      at Object.remove (node_modules/@feathersjs/adapter-commons/lib/service.js:90:12)
      at processHooks.call.then.hookObject (node_modules/@feathersjs/feathers/lib/hooks/index.js:56:27)
```

It appears that the remove hook is being called and the params are not being passed into it. If anyone could provide some guidance on tracking down why this is happening and perhaps proposing a fix, I'd much appreciate it. Attn: @daffl and @DesignByOnyx 

(Side note to @DesignByOnyx - I integrated your feedback from the other PR and focused my attention on passing through only the .sequelize member of the params rather than the entire params object.)

Other note: to see the original PR that added getModel overriding with params, please see https://github.com/feathersjs-ecosystem/feathers-sequelize/pull/166
