### PR TITLE
Use Sequelize directly to access Op

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ class Service extends AdapterService {
       throw new Error('You must provide a Sequelize Model');
     }
 
-    const defaultOps = defaultOperators(options.Model.sequelize.Op);
+    const defaultOps = defaultOperators(options.Model.sequelize.Sequelize.Op);
     const operators = Object.assign(defaultOps, options.operators);
     const whitelist = Object.keys(operators).concat(options.whitelist || []);
 


### PR DESCRIPTION
### Summary

Use Sequelize directly to access Op. In Sequelize v5 aliases has been removed from prototype https://github.com/sequelize/sequelize/issues/9372#issuecomment-421382308