### PR TITLE
Tighten up some options.Model/Sequelize/getModel related code.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,11 +24,16 @@ const defaultOperators = Op => {
 
 class Service extends AdapterService {
   constructor (options) {
-    if (!options.Model) {
-      throw new Error('You must provide a Sequelize Model');
+    let Sequelize;
+    if (options.Model) {
+      Sequelize = options.Model.sequelize.Sequelize;
+    } else if (options.Sequelize) {
+      Sequelize = options.Sequelize;
+    } else {
+      throw new Error('You must provide a Sequelize Model or the Sequelize class');
     }
 
-    const defaultOps = defaultOperators(options.Model.sequelize.Sequelize.Op);
+    const defaultOps = defaultOperators(Sequelize.Op);
     const operators = Object.assign(defaultOps, options.operators);
     const whitelist = Object.keys(operators).concat(options.whitelist || []);
 
@@ -41,10 +46,18 @@ class Service extends AdapterService {
   }
 
   get Model () {
+    if (!this.options.Model) {
+      throw new Error('The Model getter was called with no Model provided in options!');
+    } else {
+      console.warn("Warning: In order to allow for child-class overriding of getModel(params) where those params are passed through to any underlying service calls, feathers-sequelize does not recommend utilizing the .Model getter, which can't allow for any parameters to be provided. Unless it's for coverage tests, please always use getModel(params)!");
+    }
     return this.options.Model;
   }
 
   getModel (params) {
+    if (!this.options.Model) {
+      throw new Error('getModel was called without a Model present in the constructor options and without overriding getModel! Perhaps you intended to override getModel in a child class?');
+    }
     return this.options.Model;
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,9 +48,8 @@ class Service extends AdapterService {
   get Model () {
     if (!this.options.Model) {
       throw new Error('The Model getter was called with no Model provided in options!');
-    } else {
-      console.warn("Warning: In order to allow for child-class overriding of getModel(params) where those params are passed through to any underlying service calls, feathers-sequelize does not recommend utilizing the .Model getter, which can't allow for any parameters to be provided. Unless it's for coverage tests, please always use getModel(params)!");
     }
+    
     return this.options.Model;
   }
 


### PR DESCRIPTION
Firstly, some background:
feathers-sequelize allows for overriding of its getModel method
in order to let users implement their own model provider schemes;

Overriding getModel() in this way allows for a different Model to be programatically
provided any time getModel() is called.
This can allow for multi-tenancy setups where different customer models/databases
are used depending upon different criteria, such as what hostname they're connecting to,
where they are connecting from, or whatever the programmer desires.

Currently, the feathers-sequelize Service class requires that a single Model be provided
in the options passed to its constructor. The problem is, when using a getModel() override
as described above, a single Model is probably not known at the time that the feathers-sequelize
Service constructor is called.

Therefore, a Model probably shouldn't be required at construction time.

This changeset makes providing a Model optional, adds an alternative option attribute called 'Sequelize'
for providing the Sequelize class (which is currently used to derive the default Ops), and
adds some warning messages inside of the Model getter to dissaude usage of it altogether other than
for coverage tests, since using this getter doesn't allow for proper getModel() overriding.