### PR TITLE
Make sure that queries with id property work properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,10 @@ class Service extends AdapterService {
     this.raw = options.raw !== false;
   }
 
+  get Op () {
+    return this.options.Model.sequelize.Sequelize.Op;
+  }
+
   get Model () {
     return this.options.Model;
   }
@@ -151,7 +155,9 @@ class Service extends AdapterService {
     // Attach 'where' constraints, if any were used.
     const q = Object.assign({
       raw: this.raw,
-      where: Object.assign({ [this.id]: id }, where)
+      where: Object.assign({
+        [this.Op.and]: { [this.id]: id }
+      }, where)
     }, params.sequelize);
 
     let Model = this.applyScope(params);
@@ -203,7 +209,7 @@ class Service extends AdapterService {
     const mapIds = data => data.map(current => current[this.id]);
 
     if (id !== null) {
-      where[this.id] = id;
+      where[this.Op.and] = { [this.id]: id };
     }
 
     const options = Object.assign({ raw: this.raw }, params.sequelize, { where });
@@ -281,7 +287,7 @@ class Service extends AdapterService {
     const where = Object.assign({}, this.filterQuery(params).query);
 
     if (id !== null) {
-      where[this.id] = id;
+      where[this.Op.and] = { [this.id]: id };
     }
 
     const options = Object.assign({}, { where }, params.sequelize);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,7 +66,11 @@ const testSuite = adaptertests([
   '.find + paginate',
   '.find + paginate + $limit + $skip',
   '.find + paginate + $limit 0',
-  '.find + paginate + params'
+  '.find + paginate + params',
+  '.remove + id + query id',
+  '.update + id + query id',
+  '.patch + id + query id',
+  '.get + id + query id'
 ]);
 
 // The base tests require the use of Sequelize.BIGINT to avoid 'out of range errors'


### PR DESCRIPTION
When getting or modifying a single entry, if a different `id` property is in the query, the service should error.