### PR TITLE
Determine primary key name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,16 +31,12 @@ class Service extends AdapterService {
     const defaultOps = defaultOperators(options.Model.sequelize.Sequelize.Op);
     const operators = Object.assign(defaultOps, options.operators);
     const whitelist = Object.keys(operators).concat(options.whitelist || []);
-    
-    var primaryKeyName;
-    if  ( typeof options.Model.primaryKeyAttributes === 'object' && options.Model.primaryKeyAttributes[0] !== 'undefined' ) {
-      primaryKeyName = options.Model.primaryKeyAttributes[0];
-    } else {
-      primaryKeyName = 'id';
-    }
+    const { primaryKeyAttributes } = options.Model;
+    const id = typeof primaryKeyAttributes === 'object' && primaryKeyAttributes[0] !== undefined
+      ? primaryKeyAttributes[0] : 'id';
 
     super(Object.assign({
-      id: primaryKeyName,
+      id,
       operators,
       whitelist
     }, options));

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,9 +31,16 @@ class Service extends AdapterService {
     const defaultOps = defaultOperators(options.Model.sequelize.Sequelize.Op);
     const operators = Object.assign(defaultOps, options.operators);
     const whitelist = Object.keys(operators).concat(options.whitelist || []);
+    
+    var primaryKeyName;
+    if  ( typeof options.Model.primaryKeyAttributes === 'object' && options.Model.primaryKeyAttributes[0] !== 'undefined' ) {
+      primaryKeyName = options.Model.primaryKeyAttributes[0];
+    } else {
+      primaryKeyName = 'id';
+    }
 
     super(Object.assign({
-      id: 'id',
+      id: primaryKeyName,
       operators,
       whitelist
     }, options));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -184,7 +184,7 @@ describe('Feathers Sequelize Service', () => {
         events: [ 'testing' ]
       }))
       .use('/people-customid', service({
-        Model: CustomId,
+        Model: CustomId
         events: [ 'testing' ],
         id: 'customid'
       }));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -184,9 +184,8 @@ describe('Feathers Sequelize Service', () => {
         events: [ 'testing' ]
       }))
       .use('/people-customid', service({
-        Model: CustomId
-        events: [ 'testing' ],
-        id: 'customid'
+        Model: CustomId,
+        events: [ 'testing' ]
       }));
 
     it('has .Model', () => {


### PR DESCRIPTION
Determine the primary key name if specified in the model, and use that value rather than the default name 'id'.

Currently, if the primary key value is something rather than 'id', the value must be specified in the service.js file.  The proposed change will determine the primary key specified in the model.