### PR TITLE
Wraps a SequelizeDatabaseError as a GeneralError

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,6 @@ exports.errorHandler = error => {
       case 'SequelizeHostNotReachableError':
         throw wrap(new errors.Unavailable(message), error);
       case 'SequelizeHostNotFoundError':
-      case 'SequelizeDatabaseError':
         throw wrap(new errors.NotFound(message), error);
       default:
         throw wrap(new errors.GeneralError(message), error);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -98,6 +98,11 @@ describe('Feathers Sequelize Utils', () => {
       let e = new Sequelize.HostNotFoundError();
       expect(utils.errorHandler.bind(null, e)).to.throw(errors.NotFound);
     });
+
+    it('wraps a DatabaseError as a GeneralError', () => {
+      let e = new Sequelize.DatabaseError('');
+      expect(utils.errorHandler.bind(null, e)).to.throw(errors.GeneralError);
+    });
   });
 
   describe('getOrder', () => {


### PR DESCRIPTION
As mentioned in https://github.com/feathersjs-ecosystem/feathers-sequelize/issues/269, SequelizeDatabaseError should be really GeneralError. 