### PR TITLE
Fix issue with patch when using pagination by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ class Service extends AdapterService {
     if (!this.options.Model) {
       throw new Error('The Model getter was called with no Model provided in options!');
     }
-    
+
     return this.options.Model;
   }
 
@@ -256,7 +256,7 @@ class Service extends AdapterService {
     // By default we will just query for the one id. For multi patch
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
-    const ids = id === null ? this._find(params)
+    const ids = id === null ? this._getOrFind(null, params)
       .then(mapIds) : Promise.resolve([ id ]);
 
     return ids.then(idList => {


### PR DESCRIPTION
Currently patch does not disable pagination when gathering a list of IDs to be modified.

If pagination is enabled by default for a service, this causes the request to fail when patching multiple records with a query.

This commit updates the patch function to use getOrFind rather than find, with the former explicitly 
 disabling pagination.

Fixes #279 
