### PR TITLE
Lock CI to Node 11 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'node'
+  - '11'
   - '8'
 env:
   - DB=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
 sudo: false
 install: npm install
 before_script:
-  - npm install -g codeclimate-test-reporter
   - psql -c 'create database sequelize;' -U postgres
   - mysql -e 'CREATE DATABASE sequelize;'
 services:
   - postgresql
+  - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '11'
+  - 'node'
   - '8'
 env:
   - DB=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - '11'
   - '8'
 env:
   - DB=postgres


### PR DESCRIPTION
Because SQLite binaries. 

- Closes https://github.com/feathersjs-ecosystem/feathers-sequelize/issues/301
- Closes https://github.com/feathersjs-ecosystem/feathers-sequelize/issues/298
- Closes https://github.com/feathersjs-ecosystem/feathers-sequelize/issues/296
- Closes https://github.com/feathersjs-ecosystem/feathers-sequelize/issues/295