### PR TITLE
Include associations in patch and update and return proper values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -215,23 +215,17 @@ class Service extends AdapterService {
   }
 
   _patch (id, data, params = {}) {
-    const where = Object.assign({}, this.filterQuery(params).query);
-    const mapIds = data => {
-      const items = Array.isArray(data) ? data : [data];
-      return items.map(current => current[this.id]);
-    };
-
-    if (id !== null) {
-      where[this.Op.and] = { [this.id]: id };
-    }
-
-    const options = Object.assign({ raw: this.raw }, params.sequelize, { where });
     const Model = this.applyScope(params);
 
-    // By default we will just query for the one id. For multi patch
-    // we create a list of the ids of all items that will be changed
-    // to re-query them after the update
-    const ids = this._getOrFind(id, params).then(mapIds);
+    // Get a list of ids that match the id/query. Overwrite the
+    // $select because only the id is needed for this idList
+    const idQuery = Object.assign({}, params.query, { $select: [this.id] });
+    const idParams = Object.assign({}, params, { query: idQuery });
+
+    const ids = this._getOrFind(id, idParams).then(result => {
+      const items = Array.isArray(result) ? result : [result];
+      return items.map(item => item[this.id]);
+    });
 
     return ids.then(idList => {
       // Create a new query that re-queries all ids that
@@ -243,7 +237,13 @@ class Service extends AdapterService {
 
       const findParams = Object.assign({}, params, { query: findQuery });
 
-      return Model.update(_.omit(data, this.id), options)
+      const seqOptions = Object.assign(
+        { raw: this.raw },
+        params.sequelize,
+        { where: { [this.id]: { [this.Op.in]: idList } } }
+      );
+
+      return Model.update(_.omit(data, this.id), seqOptions)
         .then(() => {
           if (params.$returning !== false) {
             return this._getOrFind(id, findParams);

--- a/lib/index.js
+++ b/lib/index.js
@@ -271,7 +271,9 @@ class Service extends AdapterService {
       return instance.update(copy, seqOptions)
         .then(() => this._get(id, {
           sequelize: Object.assign({}, seqOptions, {
-            raw: this.raw
+            raw: typeof seqOptions.raw !== 'undefined'
+              ? seqOptions.raw
+              : this.raw
           })
         }));
     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -231,7 +231,7 @@ class Service extends AdapterService {
     // By default we will just query for the one id. For multi patch
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
-    const ids = this._getOrFind(id, params).then(mapIds)
+    const ids = this._getOrFind(id, params).then(mapIds);
 
     return ids.then(idList => {
       // Create a new query that re-queries all ids that

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,7 +238,7 @@ class Service extends AdapterService {
       // were originally changed
       const findQuery = Object.assign(
         { [this.id]: { $in: idList } },
-        _.pick(params.query || {}, '$select', '$sort', '$limit', '$skip')
+        this.filterQuery(params).filters
       );
 
       const findParams = Object.assign({}, params, { query: findQuery });

--- a/lib/index.js
+++ b/lib/index.js
@@ -216,7 +216,10 @@ class Service extends AdapterService {
 
   _patch (id, data, params = {}) {
     const where = Object.assign({}, this.filterQuery(params).query);
-    const mapIds = data => data.map(current => current[this.id]);
+    const mapIds = data => {
+      const items = Array.isArray(data) ? data : [data];
+      return items.map(current => current[this.id]);
+    };
 
     if (id !== null) {
       where[this.Op.and] = { [this.id]: id };
@@ -228,15 +231,17 @@ class Service extends AdapterService {
     // By default we will just query for the one id. For multi patch
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
-    const ids = id === null ? this._getOrFind(null, params)
-      .then(mapIds) : Promise.resolve([id]);
+    const ids = this._getOrFind(id, params).then(mapIds)
 
     return ids.then(idList => {
       // Create a new query that re-queries all ids that
       // were originally changed
-      const findParams = Object.assign({}, params, Object.assign({}, {
-        query: Object.assign({ [this.id]: { $in: idList } }, params.query)
-      }));
+      const findQuery = Object.assign(
+        { [this.id]: { $in: idList } },
+        _.pick(params.query || {}, '$select', '$sort', '$limit', '$skip')
+      );
+
+      const findParams = Object.assign({}, params, { query: findQuery });
 
       return Model.update(_.omit(data, this.id), options)
         .then(() => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -271,8 +271,8 @@ class Service extends AdapterService {
       return instance.update(copy, seqOptions)
         .then(() => this._get(id, {
           sequelize: Object.assign({}, seqOptions, {
-            raw: typeof seqOptions.raw !== 'undefined'
-              ? seqOptions.raw
+            raw: typeof (params.sequelize || {}).raw !== 'undefined'
+              ? params.sequelize.raw
               : this.raw
           })
         }));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -397,6 +397,25 @@ describe('Feathers Sequelize Service', () => {
 
         expect(result['orders.id']).to.exist;
       });
+
+      it('update() includes associations', async () => {
+        const params = { sequelize: { include: Order } };
+        const data = { name: 'Updated' };
+
+        const result = await people.update(kirsten.id, data, params);
+
+        expect(result['orders.id']).to.exist;
+      });
+
+      it('remove() includes associations', async () => {
+        const params = { sequelize: { include: Order } };
+
+        const result = await people.remove(kirsten.id, params);
+
+        expect(result['orders.id']).to.exist;
+
+        kirsten = await people.create({ name: 'Kirsten', age: 30 });
+      });
     });
 
     describe('Custom getters and setters', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -479,10 +479,11 @@ describe('Feathers Sequelize Service', () => {
           operators: { $between: Sequelize.Op.between }
         }));
         const ops = app.service('ops-and-whitelist');
-        const result1 = await ops.find({ query: { name: { $like: 'Beau' } } });
-        const result2 = await ops.find({ query: { name: { $between: 'Beau' } } });
-        assert.strictEqual(result1.length, 0);
-        assert.strictEqual(result2.length, 0);
+        try {
+          await ops.find({ query: { name: { $like: 'Beau' } } });
+        } catch (error) {
+          assert.ok(false, 'Should never get here');
+        }
       });
 
       it('succeeds using operator that IS whitelisted AND default', async () => {
@@ -492,8 +493,11 @@ describe('Feathers Sequelize Service', () => {
           whitelist: ['$like']
         }));
         const ops = app.service('ops-and-whitelist');
-        const result = await ops.find({ query: { name: { $like: 'Beau' } } });
-        assert.strictEqual(result.length, 0);
+        try {
+          await ops.find({ query: { name: { $like: 'Beau' } } });
+        } catch (error) {
+          assert.ok(false, 'Should never get here');
+        }
       });
 
       it('fails using an invalid operator in the whitelist', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -388,6 +388,7 @@ describe('Feathers Sequelize Service', () => {
 
         assert.strictEqual(result.total, 2);
       });
+    });
 
     describe('Custom getters and setters', () => {
       it('calls custom getters and setters (#113)', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -389,16 +389,6 @@ describe('Feathers Sequelize Service', () => {
         assert.strictEqual(result.total, 2);
       });
 
-      it('patch() uses instances when include', async () => {
-        const options = { sequelize: { include: Order } };
-        const data = { name: 'Patched' };
-
-        const result = await people.patch(kirsten.id, data, options);
-
-        expect(result['orders.id']).to.exist;
-      });
-    });
-
     describe('Custom getters and setters', () => {
       it('calls custom getters and setters (#113)', async () => {
         const value = 0;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -388,6 +388,15 @@ describe('Feathers Sequelize Service', () => {
 
         assert.strictEqual(result.total, 2);
       });
+
+      it('patch() includes associations', async () => {
+        const params = { sequelize: { include: Order } };
+        const data = { name: 'Patched' };
+
+        const result = await people.patch(kirsten.id, data, params);
+
+        expect(result['orders.id']).to.exist;
+      });
     });
 
     describe('Custom getters and setters', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -479,11 +479,7 @@ describe('Feathers Sequelize Service', () => {
           operators: { $between: Sequelize.Op.between }
         }));
         const ops = app.service('ops-and-whitelist');
-        try {
-          await ops.find({ query: { name: { $like: 'Beau' } } });
-        } catch (error) {
-          assert.ok(false, 'Should never get here');
-        }
+        await ops.find({ query: { name: { $like: 'Beau' } } });
       });
 
       it('succeeds using operator that IS whitelisted AND default', async () => {
@@ -493,11 +489,7 @@ describe('Feathers Sequelize Service', () => {
           whitelist: ['$like']
         }));
         const ops = app.service('ops-and-whitelist');
-        try {
-          await ops.find({ query: { name: { $like: 'Beau' } } });
-        } catch (error) {
-          assert.ok(false, 'Should never get here');
-        }
+        await ops.find({ query: { name: { $like: 'Beau' } } });
       });
 
       it('fails using an invalid operator in the whitelist', async () => {


### PR DESCRIPTION
This PR address two issues and merges two branches
https://github.com/feathersjs-ecosystem/feathers-sequelize/issues/346
https://github.com/feathersjs-ecosystem/feathers-sequelize/pull/349

#349 was actually previously solved and merged into master. But, it was later discovered while working on this branch that the changes here were actually a better solution. Master branch (including changes from 349) were merged into this branch. Those changes were then unset in favor of the changes made in this branch. But, the 349 branch did have a couple of nice additions to the tests and those were kept.

The changes presented in the PR as as follows

- Use the `getOrFind` method  to fetch the `idList` whether the client provided an ID or not. This ensures that if the client did provide valid ID but an invalid query that the adapter throws a 401. 

- Using `_getOrFind` on all patches also ensures that users can patch with `sequelize.include`. This solves #349 in a much more elegant way (`Model.update` does not support `include`).

- Pass the `idList` directly to the `Model.update` method. This is also how we allow the user to patch with `sequelize.includes`. Because we have already created a "true" list of ids that will be changed in `idList` (via getOrFind that supports includes), it is now passed to the `Model.update` method instead of the where clause. This means there is no need for `Model.update` to support include (which removes the bulky code written in 349). It is also safer because Sequelize is Sequelize and we can't guarantee that `Model.update({ where }) === this.getOrFind(params)`. It's also much cleaner and easier to understand IMHO.

- And finally, the original point of this PR, create a new `findQuery` that re-quires results after they are patched ensuring that the proper results are returned even if the client patched the data it originally queried.

This PR adds some super basic tests ensuring associations are returned on update, patch, and remove. 

I also noticed a little error in some tests I had actually previously written around operators and whitelists. Those were updated. The logic didn't really change, but the the tests were previously brittle and broke while working on association tests.
