### PR TITLE
fix multi-patch with default pagination

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -236,6 +236,17 @@ class Service extends AdapterService {
         { [this.id]: { $in: idList } },
         this.filterQuery(params).filters
       );
+      
+      // If `params.query` does not have a $limit but `filterQuery` does
+      // it's because of default pagination
+      // then the `$limit` should be deleted, to perform the operation for all items
+      if (
+        params.query &&
+        !Object.prototype.hasOwnProperty.call(params.query, '$limit') &&
+        Object.prototype.hasOwnProperty.call(findQuery, '$limit')
+      ) {
+        delete findQuery.$limit;
+      }
 
       const findParams = Object.assign({}, params, { query: findQuery });
 


### PR DESCRIPTION
See #363. I consider this quite hacky but it would solve my problem with multi-patch for a length of items > 10 for now. I would prefer to get this added to `@feathersjs/adapter-tests` and `@feathersjs/adapter-commons` (see issue #363) but wait the opinion of others on this.