### PR TITLE
typing: add 'operators' to SequelizeServiceOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,7 @@ import { AdapterService, ServiceOptions, InternalServiceMethods } from '@feather
 
 export interface SequelizeServiceOptions extends ServiceOptions {
   Model: any;
+  operators: any;
   raw: boolean;
 }
 


### PR DESCRIPTION
Options passed to Service constructor can have `operators`: https://github.com/feathersjs-ecosystem/feathers-sequelize/blob/master/lib/index.js#L39
But it's not defined in the types which leads to an error in typescript.