### PR TITLE
Be able to sort nulls before or after not-nulls values

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,14 @@ exports.errorHandler = error => {
 };
 
 exports.getOrder = (sort = {}) => Object.keys(sort).reduce((order, name) => {
-  order.push([name, parseInt(sort[name], 10) === 1 ? 'ASC' : 'DESC']);
+  let direction;
+  if (Array.isArray(sort[name])) {
+  direction = parseInt(sort[name][0], 10) === 1 ? 'ASC' : 'DESC';
+  direction += parseInt(sort[name][1], 10) === 1 ? ' NULLS FIRST': ' NULLS LAST';
+  } else {
+    direction = parseInt(sort[name], 10) === 1 ? 'ASC' : 'DESC';
+  }
+  order.push([name, direction]);
 
   return order;
 }, []);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -117,5 +117,21 @@ describe('Feathers Sequelize Utils', () => {
 
       expect(order).to.deep.equal([['name', 'ASC'], ['age', 'DESC']]);
     });
+
+    it('returns order properly converted with the position of the nulls', () => {
+      const order = utils.getOrder({
+        name: [1, 1],
+        lastName: [1, -1],
+        age: [-1, 1],
+        phone: [-1, -1]
+      });
+
+      expect(order).to.deep.equal([
+        ['name', 'ASC NULLS FIRST'],
+        ['lastName', 'ASC NULLS LAST'],
+        ['age', 'DESC NULLS FIRST'],
+        ['phone', 'DESC NULLS LAST']
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Null values are grouped by default at the beginning or ending according to the database, however, databases such as PostgreSQL allow you to set the position of the nulls.

With this code, we can now send an array to specify if the null values are going to be at the beginning or the end of the sorting. The first element is the order and the second element is the position of the nulls. 
```
app.service('service').find({
  query: {
    $sort: { column: [ order , nullsPosition]   //  order:  1 -> ASC  ,  -1 -> DESC
                                                //  nulls position:  1 -> NULLS FIRST ,  -1 -> NULLS LAST
  }
});
```