### PR TITLE
Prevent query prototype polution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # feathers-sequelize
 
 [![CI](https://github.com/feathersjs-ecosystem/feathers-sequelize/workflows/CI/badge.svg)](https://github.com/feathersjs-ecosystem/feathers-sequelize/actions?query=workflow%3ACI)
-[![Dependency Status](https://img.shields.io/david/feathersjs-ecosystem/feathers-sequelize.svg?style=flat-square)](https://david-dm.org/feathersjs-ecosystem/feathers-sequelize)
 [![Download Status](https://img.shields.io/npm/dm/feathers-sequelize.svg?style=flat-square)](https://www.npmjs.com/package/feathers-sequelize)
 
 A [Feathers](https://feathersjs.com) database adapter for [Sequelize](http://sequelizejs.com), an ORM for Node.js. It supports PostgreSQL, MySQL, MariaDB, SQLite and MSSQL and features transaction support, relations, read replication and more.
@@ -21,6 +20,7 @@ A [Feathers](https://feathersjs.com) database adapter for [Sequelize](http://seq
     - [Embrace the ORM](#embrace-the-orm)
     - [Setting `params.sequelize.include`](#setting-paramssequelizeinclude)
   - [Querying](#querying)
+    - [Querying a nested column](#querying-a-nested-column)
   - [Working with Sequelize Model instances](#working-with-sequelize-model-instances)
   - [Validation](#validation)
   - [Testing sequelize queries in isolation](#testing-sequelize-queries-in-isolation)

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,7 @@ class Service extends AdapterService {
       return converted;
     };
 
-    filtered.query = convertOperators(filtered.query);
+    filtered.query = Object.assign({}, convertOperators(filtered.query));
 
     return filtered;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,8 +36,8 @@ exports.errorHandler = error => {
 exports.getOrder = (sort = {}) => Object.keys(sort).reduce((order, name) => {
   let direction;
   if (Array.isArray(sort[name])) {
-  direction = parseInt(sort[name][0], 10) === 1 ? 'ASC' : 'DESC';
-  direction += parseInt(sort[name][1], 10) === 1 ? ' NULLS FIRST': ' NULLS LAST';
+    direction = parseInt(sort[name][0], 10) === 1 ? 'ASC' : 'DESC';
+    direction += parseInt(sort[name][1], 10) === 1 ? ' NULLS FIRST' : ' NULLS LAST';
   } else {
     direction = parseInt(sort[name], 10) === 1 ? 'ASC' : 'DESC';
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "feathers-sequelize",
       "version": "6.3.2",
       "license": "MIT",
       "dependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -252,6 +252,17 @@ describe('Feathers Sequelize Service', () => {
         await people.remove(person.id);
       });
 
+      it('cleans up the query prototype', async () => {
+        const page = await people.find({
+          query: {
+            name: 'Dave',
+            __proto__: []
+          }
+        });
+
+        assert.strictEqual(page.data.length, 0);
+      });
+
       it('still allows querying with Sequelize operators', async () => {
         const name = 'Age test';
         const person = await people.create({ name, age: 10 });


### PR DESCRIPTION
This is a fix for a very Sequelize specifc issue that allows to mess with the query prototype in certain cases triggering a different code path than intended.