### PR TITLE
feat: expose 'paramsToAdapter' method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -107,6 +107,47 @@ class Service extends AdapterService {
     return filtered;
   }
 
+  paramsToAdapter (id, params = {}) {
+    if (id) {
+      const { query: where } = this.filterQuery(params);
+
+      const { and } = this.Op;
+      // Attach 'where' constraints, if any were used.
+      const q = Object.assign({
+        raw: this.raw,
+        where: Object.assign(where, {
+          [and]: where[and] ? [...where[and], { [this.id]: id }] : { [this.id]: id }
+        })
+      }, params.sequelize);
+
+      return q;
+    } else {
+      const { filters, query: where } = this.filterQuery(params);
+      const order = utils.getOrder(filters.$sort);
+
+      const q = Object.assign({
+        where,
+        order,
+        limit: filters.$limit,
+        offset: filters.$skip,
+        raw: this.raw,
+        distinct: true
+      }, params.sequelize);
+
+      if (filters.$select) {
+        q.attributes = filters.$select;
+      }
+
+      // Until Sequelize fix all the findAndCount issues, a few 'hacks' are needed to get the total count correct
+
+      // Adding an empty include changes the way the count is done
+      // See: https://github.com/sequelize/sequelize/blob/7e441a6a5ca44749acd3567b59b1d6ceb06ae64b/lib/model.js#L1780-L1782
+      q.include = q.include || [];
+
+      return q;
+    }
+  }
+
   // returns either the model intance for an id or all unpaginated
   // items for `params` if id is null
   _getOrFind (id, params = {}) {
@@ -120,36 +161,18 @@ class Service extends AdapterService {
   }
 
   _find (params = {}) {
-    const { filters, query: where, paginate } = this.filterQuery(params);
-    const order = utils.getOrder(filters.$sort);
+    const { paginate } = this.filterQuery(params);
 
-    const q = Object.assign({
-      where,
-      order,
-      limit: filters.$limit,
-      offset: filters.$skip,
-      raw: this.raw,
-      distinct: true
-    }, params.sequelize);
-
-    if (filters.$select) {
-      q.attributes = filters.$select;
-    }
+    const q = this.paramsToAdapter(null, params);
 
     const Model = this.applyScope(params);
-
-    // Until Sequelize fix all the findAndCount issues, a few 'hacks' are needed to get the total count correct
-
-    // Adding an empty include changes the way the count is done
-    // See: https://github.com/sequelize/sequelize/blob/7e441a6a5ca44749acd3567b59b1d6ceb06ae64b/lib/model.js#L1780-L1782
-    q.include = q.include || [];
 
     if (paginate && paginate.default) {
       return Model.findAndCountAll(q).then(result => {
         return {
           total: result.count,
-          limit: filters.$limit,
-          skip: filters.$skip || 0,
+          limit: q.limit,
+          skip: q.offset || 0,
           data: result.rows
         };
       }).catch(utils.errorHandler);
@@ -159,16 +182,7 @@ class Service extends AdapterService {
   }
 
   _get (id, params = {}) {
-    const { query: where } = this.filterQuery(params);
-
-    const { and } = this.Op;
-    // Attach 'where' constraints, if any were used.
-    const q = Object.assign({
-      raw: this.raw,
-      where: Object.assign(where, {
-        [and]: where[and] ? [...where[and], { [this.id]: id }] : { [this.id]: id }
-      })
-    }, params.sequelize);
+    const q = this.paramsToAdapter(id, params);
 
     const Model = this.applyScope(params);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -549,6 +549,69 @@ describe('Feathers Sequelize Service', () => {
 
       await people.remove(person.id);
     });
+
+    describe('utility methods', async () => {
+      const people = app.service('people');
+
+      beforeEach(async () => {
+        await people.create({ name: 'Kirsten', age: 10, time: 100 });
+        await people.create({ name: 'John', age: 15, time: 100 });
+        await people.create({ name: 'Jane', age: 20, time: 100 });
+      });
+
+      afterEach(() => people.remove(null).catch(() => {}));
+
+      it('can use min', async () => {
+        const params = { query: { age: { $gt: 10 } } };
+        const adapterParams = people.paramsToAdapter(null, params);
+        const result = await people.Model.min('age', adapterParams);
+        assert.strictEqual(result, 15);
+      });
+
+      it('can use max', async () => {
+        const params = { query: { age: { $lt: 20 } } };
+        const adapterParams = people.paramsToAdapter(null, params);
+        const result = await people.Model.max('age', adapterParams);
+        assert.strictEqual(result, 15);
+      });
+
+      it('can use sum', async () => {
+        const params = { query: { age: { $lt: 20 } } };
+        const adapterParams = people.paramsToAdapter(null, params);
+        const result = await people.Model.sum('age', adapterParams);
+        assert.strictEqual(result, 25);
+      });
+
+      it('can use increment', async () => {
+        let kirsten = (await people.find({ query: { name: 'Kirsten' } })).data[0];
+
+        assert.strictEqual(kirsten.age, 10);
+        assert.strictEqual(kirsten.time, 100);
+
+        const adapterParams = people.paramsToAdapter(null, { query: { id: kirsten.id } });
+        await people.Model.increment({ age: 5, time: 50 }, adapterParams);
+
+        kirsten = (await people.find({ query: { name: 'Kirsten' } })).data[0];
+
+        assert.strictEqual(kirsten.age, 15);
+        assert.strictEqual(kirsten.time, 150);
+      });
+
+      it('can use decrement', async () => {
+        let kirsten = (await people.find({ query: { name: 'Kirsten' } })).data[0];
+
+        assert.strictEqual(kirsten.age, 10);
+        assert.strictEqual(kirsten.time, 100);
+
+        const adapterParams = people.paramsToAdapter(null, { query: { id: kirsten.id } });
+        await people.Model.decrement({ age: 5, time: 50 }, adapterParams);
+
+        kirsten = (await people.find({ query: { name: 'Kirsten' } })).data[0];
+
+        assert.strictEqual(kirsten.age, 5);
+        assert.strictEqual(kirsten.time, 50);
+      });
+    });
   });
 
   describe('ORM functionality', () => {


### PR DESCRIPTION
This is a refactor which exposes a new `paramsToAdapter` function. It's purpose is to transform feathers params to a `sequelize` query and have that available from the outside. It's useful for native `sequelize` functions, like `min`, `max`, `sum`, `increment` and `decrement` (see https://sequelize.org/docs/v6/core-concepts/model-querying-basics/#utility-methods).

So it's not a breaking change and doesn't change much for existing use cases but it opens up some opportunities. The tests for utility functions are just some use cases.