### PR TITLE
Do not allow raw attribute selects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,7 +133,7 @@ class Service extends AdapterService {
     }, params.sequelize);
 
     if (filters.$select) {
-      q.attributes = filters.$select;
+      q.attributes = filters.$select.map(select => `${select}`);
     }
 
     const Model = this.applyScope(params);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -293,6 +293,12 @@ describe('Feathers Sequelize Service', () => {
         await people.remove(person.id);
       });
 
+      it('does not allow raw attribute $select ', async () => {
+        await assert.rejects(() => people.find({
+          query: { $select: [['(sqlite_version())', 'x']] }
+        }));
+      });
+
       it('hides the Sequelize error in ERROR symbol', async () => {
         try {
           await people.create({


### PR DESCRIPTION
This is another Sequelize silliness where you'd think an ORM would prevent you from allowing things like this. The `$select` entries always need to be strings.