### PR TITLE
Allow join queries on remove

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -279,28 +279,45 @@ class Service extends AdapterService {
   }
 
   _remove (id, params = {}) {
-    const opts = Object.assign({ raw: this.raw }, params);
-    const where = Object.assign({}, this.filterQuery(params).query);
-
-    if (id !== null) {
-      where[this.Op.and] = { [this.id]: id };
-    }
-
-    const options = Object.assign({}, { where }, params.sequelize);
-
     const Model = this.applyScope(params);
 
-    if (params.$returning !== false) {
-      return this._getOrFind(id, opts).then(data => {
-        return Model.destroy(options).then(() => data);
-      })
-        .then(select(params, this.id))
-        .catch(utils.errorHandler);
-    } else {
-      return Model.destroy(options).then(() => Promise.resolve([]))
-        .then(select(params, this.id))
-        .catch(utils.errorHandler);
+    if (params.$returning === false) {
+      params = {
+        ...params,
+        query: {
+          ...params.query,
+          $select: [this.id]
+        }
+      };
+    } else if (params.query && params.query.$select) {
+      params = {
+        ...params,
+        query: {
+          ...params.query,
+          $select: [...params.query.$select, this.id]
+        }
+      };
     }
+
+    return this._getOrFind(id, params).then(results => {
+      const items = Array.isArray(results) ? results : [results];
+      const idList = items.map(item => item[this.id]);
+
+      const seqOptions = Object.assign(
+        { raw: this.raw },
+        params.sequelize,
+        { where: { [this.id]: { [this.Op.in]: idList } } }
+      );
+
+      return Model.destroy(seqOptions)
+        .then(() => {
+          if (params.$returning === false) {
+            return Promise.resolve([]);
+          } else {
+            return results;
+          }
+        });
+    }).then(select(params, this.id)).catch(utils.errorHandler);
   }
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/feathersjs-ecosystem/feathers-sequelize/issues/402

The `remove` method has been updated to work more similarly to the `patch`. This allows for a more consistent querying and sequelize options.