### PR TITLE
Fix/update dependencies infer paginate params

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         database: ['sqlite', 'postgres']
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,43 +9,43 @@
       "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
-        "@feathersjs/adapter-commons": "^5.0.1",
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1"
+        "@feathersjs/adapter-commons": "^5.0.6",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6"
       },
       "devDependencies": {
-        "@feathersjs/adapter-tests": "^5.0.1",
-        "@feathersjs/express": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
-        "@types/chai": "^4.3.4",
+        "@feathersjs/adapter-tests": "^5.0.6",
+        "@feathersjs/express": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
+        "@types/chai": "^4.3.5",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^18.15.11",
-        "@types/pg": "^8.6.6",
-        "@typescript-eslint/eslint-plugin": "^5.57.0",
-        "@typescript-eslint/parser": "^5.57.0",
+        "@types/node": "^20.3.1",
+        "@types/pg": "^8.10.2",
+        "@typescript-eslint/eslint-plugin": "^5.60.0",
+        "@typescript-eslint/parser": "^5.60.0",
         "body-parser": "^1.20.2",
-        "c8": "^7.13.0",
+        "c8": "^8.0.0",
         "chai": "^4.3.7",
-        "eslint": "^8.37.0",
+        "eslint": "^8.43.0",
         "mocha": "^10.2.0",
-        "mysql2": "^3.2.0",
-        "npm-check-updates": "^16.9.0",
-        "pg": "^8.10.0",
+        "mysql2": "^3.4.0",
+        "npm-check-updates": "^16.10.12",
+        "pg": "^8.11.0",
         "pg-hstore": "^2.3.4",
-        "sequelize": "^6.30.0",
+        "sequelize": "^6.32.1",
         "shx": "^0.3.4",
         "sqlite3": "^5.1.6",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.3"
+        "typescript": "^5.1.3"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
@@ -107,14 +107,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
-      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.1",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -152,22 +152,22 @@
       "dev": true
     },
     "node_modules/@eslint/js": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
-      "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@feathersjs/adapter-commons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-5.0.1.tgz",
-      "integrity": "sha512-s1ERoHP6tR1gUQIma4Wd6xSdHHHPfsm2H86KHiLy6rrIjtgwgMysxgD8cFjdSgUfp1QzyY8W2G9pqY7kClqjhQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-5.0.6.tgz",
+      "integrity": "sha512-ilkKn3/Y9RQL/gk/3h7QbytDo49JdJUSkI4JaTuEnb55YjiVEJlECrfZz7yV0fFbBI1yRl+OHJsWjWKMAbkPEQ==",
       "dependencies": {
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1"
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6"
       },
       "engines": {
         "node": ">= 12"
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@feathersjs/adapter-tests": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-tests/-/adapter-tests-5.0.1.tgz",
-      "integrity": "sha512-30yMqZ2YA0B20RGgcK40RpcB8cM571M0iovBHq17Dy1fUIt19MPjdvClZQrUM5RuNbC9mnaixl16b6UNiUEkiQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-tests/-/adapter-tests-5.0.6.tgz",
+      "integrity": "sha512-RHzzVjDtE1zAJNEYhdqZ06kY+Xc6VUDB0b02+wCKFguCGy/Ewe7qbK2UzCTokTCigwrjTVYReqTTvp3AQP7DrQ==",
       "dev": true,
       "engines": {
         "node": ">= 12"
@@ -191,18 +191,18 @@
       }
     },
     "node_modules/@feathersjs/authentication": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/authentication/-/authentication-5.0.1.tgz",
-      "integrity": "sha512-bDCIjETtJR+w22LT8nD9MVFBgaCjKVwxgGH8ObjHgm3EB+TXovZjmn8OaZvr5GkNxV9kQTuNK71IVekqC6cgRg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/authentication/-/authentication-5.0.6.tgz",
+      "integrity": "sha512-9fmFjyBmy52Fr5niao6RzpG3ZRi3s/iIZt42OxEECxHpT2K1VDtrIgQGNfA0CJpnlBLfHuFq/wWFFiFvMcmJtQ==",
       "dev": true,
       "dependencies": {
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
         "@feathersjs/hooks": "^0.8.1",
-        "@feathersjs/schema": "^5.0.1",
-        "@feathersjs/transport-commons": "^5.0.1",
-        "@types/jsonwebtoken": "^9.0.1",
+        "@feathersjs/schema": "^5.0.6",
+        "@feathersjs/transport-commons": "^5.0.6",
+        "@types/jsonwebtoken": "^9.0.2",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
         "long-timeout": "^0.1.1",
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@feathersjs/commons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.1.tgz",
-      "integrity": "sha512-SNnWoUx/FPiEw8B+2kYLOCKxPRBQ08m5nv1VU80nEMIxURD1z079XsTJBJYKuaqjr5V3LvMrpdmisJ8CLKfJCA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.6.tgz",
+      "integrity": "sha512-AVX6+JPb+KT9Ya4ASMAErVfKnnEN1dzwiWK03cHA2IvUrhzLBPGNoe/t+ph4L7BNl8JSK/nds3XOvf3/IcdOcg==",
       "engines": {
         "node": ">= 12"
       },
@@ -229,27 +229,27 @@
       }
     },
     "node_modules/@feathersjs/errors": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-5.0.1.tgz",
-      "integrity": "sha512-SOJ9a9VpWn5w0o3cqYTmS1EG0h7w0uLQI9k556Z2qLatdrgH7Lt6aO2FIeIV842iqLheiXA62KDKCpDTKTAHzA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-5.0.6.tgz",
+      "integrity": "sha512-lJAKKOpV6+gdah9TcS65f93gPGUx6SEQojK3bp6r51RgMP9SBD68JfrUoTX7pVDN6+hBBOfwT+1QiAyDw7mvAQ==",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/@feathersjs/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-3nV7Za87IQurgd34sxVTUcsnRc1+ll2zVI0iXjKp7Yt4kfJhn75cNa4J4wO+PMqNVXsdRCUciJ0ge8kKhhzRFQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-uL2/swSII5E3tLJ7KuTFaqCIcJfRGe31KtYwhbWDDvQ38K4GjoE9n2XNql8Mb7QuVidCDD1FrxysK8G3bnSInw==",
       "dev": true,
       "dependencies": {
-        "@feathersjs/authentication": "^5.0.1",
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
-        "@feathersjs/transport-commons": "^5.0.1",
+        "@feathersjs/authentication": "^5.0.6",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
+        "@feathersjs/transport-commons": "^5.0.6",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
-        "@types/express-serve-static-core": "^4.17.33",
+        "@types/express-serve-static-core": "^4.17.35",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "express": "^4.18.2"
@@ -263,11 +263,11 @@
       }
     },
     "node_modules/@feathersjs/feathers": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-5.0.1.tgz",
-      "integrity": "sha512-9eQsmcN8SoRt+APtrB/Dfjo9zSvibuMNjkidHhqTu93UCEd7TysTv7Q3IRwXGoJCialnwwVIgoK9NOhjKe45ug==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-5.0.6.tgz",
+      "integrity": "sha512-aYqeA7SyAhClxONhlVxY1zSlKTSef9OtpvInNpYvUHlJK4G9gRRk2KytwEG4W/ipCl88TLTXjZAaWyiMdfLgcw==",
       "dependencies": {
-        "@feathersjs/commons": "^5.0.1",
+        "@feathersjs/commons": "^5.0.6",
         "@feathersjs/hooks": "^0.8.1",
         "events": "^3.3.0"
       },
@@ -288,20 +288,20 @@
       }
     },
     "node_modules/@feathersjs/schema": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/schema/-/schema-5.0.1.tgz",
-      "integrity": "sha512-L2EEtitnrb3zONkYPyi64vXx8JWT1yQm9V00eVGzTKqW1m/E0TDa7GHtrg8Il9Q11FJfnf/C1f4vic2j26ZHSQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/schema/-/schema-5.0.6.tgz",
+      "integrity": "sha512-2Vm3nD9mhvo2yY3AKkRaociNqEgWEb5DQcwkGdAtq/W7G2eOTYccTf41/ywfToCUBWh+kH+ncZ5W9+mGauG3tQ==",
       "dev": true,
       "dependencies": {
-        "@feathersjs/adapter-commons": "^5.0.1",
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
+        "@feathersjs/adapter-commons": "^5.0.6",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
         "@feathersjs/hooks": "^0.8.1",
-        "@types/json-schema": "^7.0.11",
+        "@types/json-schema": "^7.0.12",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "json-schema-to-ts": "^2.7.2"
+        "json-schema-to-ts": "^2.9.1"
       },
       "engines": {
         "node": ">= 12"
@@ -312,14 +312,14 @@
       }
     },
     "node_modules/@feathersjs/transport-commons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/transport-commons/-/transport-commons-5.0.1.tgz",
-      "integrity": "sha512-BrTSIH/oubvT2N/tYrMTIGgedRbhCV5kRoxJWvgc6Ne2tCTurxKiLTw0tDcKohGy3hiEtPst9WBtkKaPLzNsZg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/transport-commons/-/transport-commons-5.0.6.tgz",
+      "integrity": "sha512-dJCH7t+DyPl39zsxamv9tEy2GBOPUalezFwvdTNCQH4e8ZuHhnuVFtO1dSWE+Ox00fLkOyHUK487lbn1gYp9Wg==",
       "dev": true,
       "dependencies": {
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
         "encodeurl": "^1.0.2",
         "lodash": "^4.17.21"
       },
@@ -338,9 +338,9 @@
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -369,6 +369,73 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -656,6 +723,16 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pnpm/network.ca-file": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.1.tgz",
@@ -794,9 +871,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "node_modules/@types/compression": {
@@ -818,9 +895,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
@@ -839,14 +916,15 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "version": "4.17.35",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
+      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -862,15 +940,15 @@
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
-      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -895,20 +973,77 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
     },
     "node_modules/@types/pg": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
-      "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.10.2.tgz",
+      "integrity": "sha512-MKFs9P6nJ+LAeHLU3V0cODEOgyThJ3OAnmOlsZsxux6sfQs3HRXR5bBn7xG5DjckEFhTAxsXi7k7cd0pCMxpJw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
-        "pg-types": "^2.2.0"
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.1.tgz",
+      "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.0.1",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.0.1.tgz",
+      "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/qs": {
@@ -924,9 +1059,25 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/send/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
     "node_modules/@types/serve-static": {
@@ -940,21 +1091,21 @@
       }
     },
     "node_modules/@types/validator": {
-      "version": "13.7.7",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.7.tgz",
-      "integrity": "sha512-jiEw2kTUJ8Jsh4A1K4b5Pkjj9Xz6FktLLOQ36ZVLRkmxFbpTvAV2VRoKMojz8UlZxNg/2dZqzpigH4JYn1bkQg==",
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
-      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
+      "integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/type-utils": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/type-utils": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -980,14 +1131,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
-      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.0.tgz",
+      "integrity": "sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1007,13 +1158,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
-      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.0.tgz",
+      "integrity": "sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0"
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1024,13 +1175,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
-      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
+      "integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1051,9 +1202,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
-      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.0.tgz",
+      "integrity": "sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1064,13 +1215,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
-      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.0.tgz",
+      "integrity": "sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1091,17 +1242,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
-      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.0.tgz",
+      "integrity": "sha512-ba51uMqDtfLQ5+xHtwlO84vkdjrqNzOnqrnwbMHMRY8Tqeme8C2Q8Fc7LajfGR+e3/4LoYiWXUM6BpIIbHJ4hQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -1117,12 +1268,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
-      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.0.tgz",
+      "integrity": "sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/types": "5.60.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1591,9 +1742,9 @@
       }
     },
     "node_modules/c8": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.13.0.tgz",
-      "integrity": "sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.0.tgz",
+      "integrity": "sha512-XHA5vSfCLglAc0Xt8eLBZMv19lgiBSjnb1FLAQgnwkuhJYEonpilhEB4Ea3jPAbm0FhD6VVJrc0z73jPe7JyGQ==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -1613,7 +1764,7 @@
         "c8": "bin/c8.js"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=12"
       }
     },
     "node_modules/cacache": {
@@ -2372,9 +2523,9 @@
       }
     },
     "node_modules/dottie": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
-      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
+      "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==",
       "dev": true
     },
     "node_modules/eastasianwidth": {
@@ -2491,16 +2642,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
-      "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.2",
-        "@eslint/js": "8.37.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.43.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -2509,9 +2660,9 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.4.0",
-        "espree": "^9.5.1",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2519,13 +2670,12 @@
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "globals": "^13.19.0",
-        "grapheme-splitter": "^1.0.4",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -2561,9 +2711,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2589,9 +2739,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2599,6 +2749,9 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/estraverse": {
@@ -2617,14 +2770,14 @@
       "dev": true
     },
     "node_modules/espree": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3258,6 +3411,12 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3791,16 +3950,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
+      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true
-    },
-    "node_modules/js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "node_modules/js-yaml": {
@@ -3840,9 +4011,9 @@
       }
     },
     "node_modules/json-schema-to-ts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.9.1.tgz",
+      "integrity": "sha512-8MNpRGERlCUWYeJwsWkMrJ0MWzBz49dfqpG+n9viiIlP4othaahbiaNQZuBzmPxRLUhOv1QJMCzW5WE8nHFGIQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -4569,12 +4740,12 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.37",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
-      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
       "dev": true,
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -4587,16 +4758,16 @@
       "dev": true
     },
     "node_modules/mysql2": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.2.0.tgz",
-      "integrity": "sha512-0Vn6a9WSrq6fWwvPgrvIwnOCldiEcgbzapVRDAtDZ4cMTxN7pnGqCTx8EG32S/NYXl6AXkdO+9hV1tSIi/LigA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.4.0.tgz",
+      "integrity": "sha512-l952dVcdWVfEIIxMQ1PNSPHYY2htylG7H9ahrQe9lIgDpEMg3hB0S88OhC/loNSZpV8OcywSjgOzjSjEUiuwiQ==",
       "dev": true,
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru-cache": "^7.14.1",
+        "lru-cache": "^8.0.0",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
@@ -4618,12 +4789,12 @@
       }
     },
     "node_modules/mysql2/node_modules/lru-cache": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
-      "integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=16.14"
       }
     },
     "node_modules/named-placeholders": {
@@ -4830,9 +5001,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.9.0.tgz",
-      "integrity": "sha512-AOAAre4AAPzB5p41E8vbkisx7FypdNCy4mkiF4mMUl6ptOUVkaMGlWVx1eqgmaoraeAnvhyByIGS+4LN7U+XHg==",
+      "version": "16.10.12",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.10.12.tgz",
+      "integrity": "sha512-js/Gg9+5RTyOQZnmFcPswLxf4sK/H5AE/8bl4tkleLJTC1gXhQqqELUFwXqppNvx488aXxN52ZY9k9MSSvEW2A==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.2.0",
@@ -4845,26 +5016,26 @@
         "globby": "^11.0.4",
         "hosted-git-info": "^5.1.0",
         "ini": "^4.0.0",
+        "js-yaml": "^4.1.0",
         "json-parse-helpfulerror": "^1.0.3",
         "jsonlines": "^0.1.1",
         "lodash": "^4.17.21",
-        "minimatch": "^7.4.3",
+        "minimatch": "^9.0.0",
         "p-map": "^4.0.0",
         "pacote": "15.1.1",
         "parse-github-url": "^1.0.2",
         "progress": "^2.0.3",
-        "prompts-ncu": "^2.5.1",
+        "prompts-ncu": "^3.0.0",
         "rc-config-loader": "^4.1.2",
         "remote-git-tags": "^3.0.0",
-        "rimraf": "^4.4.1",
-        "semver": "^7.3.8",
+        "rimraf": "^5.0.0",
+        "semver": "^7.4.0",
         "semver-utils": "^1.1.4",
         "source-map-support": "^0.5.21",
         "spawn-please": "^2.0.1",
         "strip-json-comments": "^5.0.0",
         "untildify": "^4.0.0",
-        "update-notifier": "^6.0.2",
-        "yaml": "^2.2.1"
+        "update-notifier": "^6.0.2"
       },
       "bin": {
         "ncu": "build/src/bin/cli.js",
@@ -4895,16 +5066,36 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/npm-check-updates/node_modules/glob": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
-      "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+    "node_modules/npm-check-updates/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
       "dev": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^7.4.1",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm-check-updates/node_modules/glob": {
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
+      "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4923,40 +5114,52 @@
       }
     },
     "node_modules/npm-check-updates/node_modules/minimatch": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-check-updates/node_modules/minipass": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
-      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm-check-updates/node_modules/rimraf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
+      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
       "dev": true,
       "dependencies": {
-        "glob": "^9.2.0"
+        "glob": "^10.2.5"
       },
       "bin": {
         "rimraf": "dist/cjs/src/bin.js"
       },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm-check-updates/node_modules/signal-exit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -5171,6 +5374,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -5417,13 +5626,13 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.3.tgz",
-      "integrity": "sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^7.14.1",
-        "minipass": "^4.0.2"
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5433,21 +5642,21 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/path-scurry/node_modules/minipass": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
-      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-to-regexp": {
@@ -5475,14 +5684,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.10.0.tgz",
-      "integrity": "sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz",
+      "integrity": "sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==",
       "dev": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
+        "pg-connection-string": "^2.6.0",
         "pg-pool": "^3.6.0",
         "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
@@ -5490,6 +5699,9 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -5500,10 +5712,17 @@
         }
       }
     },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.0.tgz",
+      "integrity": "sha512-tGM8/s6frwuAIyRcJ6nWcIvd3+3NmUKIs6OjviIm1HPPFEt5MzQDOTBQyhPWg/m0kCl95M6gA1JaIXtS8KovOA==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.0.tgz",
+      "integrity": "sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg==",
       "dev": true
     },
     "node_modules/pg-hstore": {
@@ -5525,6 +5744,15 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pg-pool": {
@@ -5618,6 +5846,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/postgres-range": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
+      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
+      "dev": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5665,16 +5899,16 @@
       }
     },
     "node_modules/prompts-ncu": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-2.5.1.tgz",
-      "integrity": "sha512-Hdd7GgV7b76Yh9FP9HL1D9xqtJCJdVPpiM2vDtuoc8W1KfweJe15gutFYmxkq83ViFaagFM8K0UcPCQ/tZq8bA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-3.0.0.tgz",
+      "integrity": "sha512-qyz9UxZ5MlPKWVhWrCmSZ1ahm2GVYdjLb8og2sg0IPth1KRuhcggHGuijz0e41dkx35p1t1q3GRISGH7QGALFA==",
       "dev": true,
       "dependencies": {
         "kleur": "^4.0.1",
         "sisteransi": "^1.0.5"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/proto-list": {
@@ -6076,9 +6310,9 @@
       }
     },
     "node_modules/retry-as-promised": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.3.tgz",
-      "integrity": "sha512-SEvMa4khHvpU/o6zgh7sK24qm6rxVgKnrSyzb5POeDvZx5N9Bf0s5sQsQ4Fl+HjRp0X+w2UzACGfUnXtx6cJ9Q==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA==",
       "dev": true
     },
     "node_modules/reusify": {
@@ -6156,9 +6390,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6243,9 +6477,9 @@
       "dev": true
     },
     "node_modules/sequelize": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.30.0.tgz",
-      "integrity": "sha512-VxQ3gB+isefL8Ic3GDUR6Y8Zwu1ctWNUlffcdSClsLkQ0mwgoLQv3cI3cDwSVn9wZJk0AEwMSm1TYFFRqmcR0A==",
+      "version": "6.32.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.32.1.tgz",
+      "integrity": "sha512-3Iv0jruv57Y0YvcxQW7BE56O7DC1BojcfIrqh6my+IQwde+9u/YnuYHzK+8kmZLhLvaziRT1eWu38nh9yVwn/g==",
       "dev": true,
       "funding": [
         {
@@ -6254,21 +6488,21 @@
         }
       ],
       "dependencies": {
-        "@types/debug": "^4.1.7",
-        "@types/validator": "^13.7.1",
-        "debug": "^4.3.3",
-        "dottie": "^2.0.2",
-        "inflection": "^1.13.2",
+        "@types/debug": "^4.1.8",
+        "@types/validator": "^13.7.17",
+        "debug": "^4.3.4",
+        "dottie": "^2.0.4",
+        "inflection": "^1.13.4",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
-        "moment-timezone": "^0.5.35",
-        "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^7.0.3",
-        "semver": "^7.3.5",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.43",
+        "pg-connection-string": "^2.6.0",
+        "retry-as-promised": "^7.0.4",
+        "semver": "^7.5.1",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",
-        "validator": "^13.7.0",
+        "validator": "^13.9.0",
         "wkx": "^0.5.0"
       },
       "engines": {
@@ -6919,7 +7153,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -7246,16 +7508,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
-      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/underscore": {
@@ -7447,9 +7709,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -7594,9 +7856,9 @@
       "dev": true
     },
     "node_modules/wrap-ansi": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
-      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -7605,6 +7867,24 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -7726,15 +8006,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -7813,9 +8084,9 @@
   },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
@@ -7859,14 +8130,14 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
-      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.1",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -7896,40 +8167,40 @@
       }
     },
     "@eslint/js": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.37.0.tgz",
-      "integrity": "sha512-x5vzdtOOGgFVDCUs81QRB2+liax8rFg3+7hqM+QhBG0/G3F1ZsoYl97UrqgHgQ9KKT7G6c4V+aTUCgu/n22v1A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true
     },
     "@feathersjs/adapter-commons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-5.0.1.tgz",
-      "integrity": "sha512-s1ERoHP6tR1gUQIma4Wd6xSdHHHPfsm2H86KHiLy6rrIjtgwgMysxgD8cFjdSgUfp1QzyY8W2G9pqY7kClqjhQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-5.0.6.tgz",
+      "integrity": "sha512-ilkKn3/Y9RQL/gk/3h7QbytDo49JdJUSkI4JaTuEnb55YjiVEJlECrfZz7yV0fFbBI1yRl+OHJsWjWKMAbkPEQ==",
       "requires": {
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1"
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6"
       }
     },
     "@feathersjs/adapter-tests": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-tests/-/adapter-tests-5.0.1.tgz",
-      "integrity": "sha512-30yMqZ2YA0B20RGgcK40RpcB8cM571M0iovBHq17Dy1fUIt19MPjdvClZQrUM5RuNbC9mnaixl16b6UNiUEkiQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-tests/-/adapter-tests-5.0.6.tgz",
+      "integrity": "sha512-RHzzVjDtE1zAJNEYhdqZ06kY+Xc6VUDB0b02+wCKFguCGy/Ewe7qbK2UzCTokTCigwrjTVYReqTTvp3AQP7DrQ==",
       "dev": true
     },
     "@feathersjs/authentication": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/authentication/-/authentication-5.0.1.tgz",
-      "integrity": "sha512-bDCIjETtJR+w22LT8nD9MVFBgaCjKVwxgGH8ObjHgm3EB+TXovZjmn8OaZvr5GkNxV9kQTuNK71IVekqC6cgRg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/authentication/-/authentication-5.0.6.tgz",
+      "integrity": "sha512-9fmFjyBmy52Fr5niao6RzpG3ZRi3s/iIZt42OxEECxHpT2K1VDtrIgQGNfA0CJpnlBLfHuFq/wWFFiFvMcmJtQ==",
       "dev": true,
       "requires": {
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
         "@feathersjs/hooks": "^0.8.1",
-        "@feathersjs/schema": "^5.0.1",
-        "@feathersjs/transport-commons": "^5.0.1",
-        "@types/jsonwebtoken": "^9.0.1",
+        "@feathersjs/schema": "^5.0.6",
+        "@feathersjs/transport-commons": "^5.0.6",
+        "@types/jsonwebtoken": "^9.0.2",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
         "long-timeout": "^0.1.1",
@@ -7937,40 +8208,40 @@
       }
     },
     "@feathersjs/commons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.1.tgz",
-      "integrity": "sha512-SNnWoUx/FPiEw8B+2kYLOCKxPRBQ08m5nv1VU80nEMIxURD1z079XsTJBJYKuaqjr5V3LvMrpdmisJ8CLKfJCA=="
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.6.tgz",
+      "integrity": "sha512-AVX6+JPb+KT9Ya4ASMAErVfKnnEN1dzwiWK03cHA2IvUrhzLBPGNoe/t+ph4L7BNl8JSK/nds3XOvf3/IcdOcg=="
     },
     "@feathersjs/errors": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-5.0.1.tgz",
-      "integrity": "sha512-SOJ9a9VpWn5w0o3cqYTmS1EG0h7w0uLQI9k556Z2qLatdrgH7Lt6aO2FIeIV842iqLheiXA62KDKCpDTKTAHzA=="
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-5.0.6.tgz",
+      "integrity": "sha512-lJAKKOpV6+gdah9TcS65f93gPGUx6SEQojK3bp6r51RgMP9SBD68JfrUoTX7pVDN6+hBBOfwT+1QiAyDw7mvAQ=="
     },
     "@feathersjs/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-3nV7Za87IQurgd34sxVTUcsnRc1+ll2zVI0iXjKp7Yt4kfJhn75cNa4J4wO+PMqNVXsdRCUciJ0ge8kKhhzRFQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-uL2/swSII5E3tLJ7KuTFaqCIcJfRGe31KtYwhbWDDvQ38K4GjoE9n2XNql8Mb7QuVidCDD1FrxysK8G3bnSInw==",
       "dev": true,
       "requires": {
-        "@feathersjs/authentication": "^5.0.1",
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
-        "@feathersjs/transport-commons": "^5.0.1",
+        "@feathersjs/authentication": "^5.0.6",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
+        "@feathersjs/transport-commons": "^5.0.6",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
-        "@types/express-serve-static-core": "^4.17.33",
+        "@types/express-serve-static-core": "^4.17.35",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "express": "^4.18.2"
       }
     },
     "@feathersjs/feathers": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-5.0.1.tgz",
-      "integrity": "sha512-9eQsmcN8SoRt+APtrB/Dfjo9zSvibuMNjkidHhqTu93UCEd7TysTv7Q3IRwXGoJCialnwwVIgoK9NOhjKe45ug==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-5.0.6.tgz",
+      "integrity": "sha512-aYqeA7SyAhClxONhlVxY1zSlKTSef9OtpvInNpYvUHlJK4G9gRRk2KytwEG4W/ipCl88TLTXjZAaWyiMdfLgcw==",
       "requires": {
-        "@feathersjs/commons": "^5.0.1",
+        "@feathersjs/commons": "^5.0.6",
         "@feathersjs/hooks": "^0.8.1",
         "events": "^3.3.0"
       }
@@ -7981,31 +8252,31 @@
       "integrity": "sha512-q/OGjm2BEhT9cHYYcMZR4YKX4lHyufBJmi5Dz+XRM5YqUuEg9MYtR45CWgDiC1klrd2srNSsdmGNVU1otL4+0Q=="
     },
     "@feathersjs/schema": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/schema/-/schema-5.0.1.tgz",
-      "integrity": "sha512-L2EEtitnrb3zONkYPyi64vXx8JWT1yQm9V00eVGzTKqW1m/E0TDa7GHtrg8Il9Q11FJfnf/C1f4vic2j26ZHSQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/schema/-/schema-5.0.6.tgz",
+      "integrity": "sha512-2Vm3nD9mhvo2yY3AKkRaociNqEgWEb5DQcwkGdAtq/W7G2eOTYccTf41/ywfToCUBWh+kH+ncZ5W9+mGauG3tQ==",
       "dev": true,
       "requires": {
-        "@feathersjs/adapter-commons": "^5.0.1",
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
+        "@feathersjs/adapter-commons": "^5.0.6",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
         "@feathersjs/hooks": "^0.8.1",
-        "@types/json-schema": "^7.0.11",
+        "@types/json-schema": "^7.0.12",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "json-schema-to-ts": "^2.7.2"
+        "json-schema-to-ts": "^2.9.1"
       }
     },
     "@feathersjs/transport-commons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@feathersjs/transport-commons/-/transport-commons-5.0.1.tgz",
-      "integrity": "sha512-BrTSIH/oubvT2N/tYrMTIGgedRbhCV5kRoxJWvgc6Ne2tCTurxKiLTw0tDcKohGy3hiEtPst9WBtkKaPLzNsZg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@feathersjs/transport-commons/-/transport-commons-5.0.6.tgz",
+      "integrity": "sha512-dJCH7t+DyPl39zsxamv9tEy2GBOPUalezFwvdTNCQH4e8ZuHhnuVFtO1dSWE+Ox00fLkOyHUK487lbn1gYp9Wg==",
       "dev": true,
       "requires": {
-        "@feathersjs/commons": "^5.0.1",
-        "@feathersjs/errors": "^5.0.1",
-        "@feathersjs/feathers": "^5.0.1",
+        "@feathersjs/commons": "^5.0.6",
+        "@feathersjs/errors": "^5.0.6",
+        "@feathersjs/feathers": "^5.0.6",
         "encodeurl": "^1.0.2",
         "lodash": "^4.17.21"
       }
@@ -8017,9 +8288,9 @@
       "dev": true
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -8038,6 +8309,54 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
+      }
     },
     "@istanbuljs/schema": {
       "version": "0.1.3",
@@ -8263,6 +8582,13 @@
         }
       }
     },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true
+    },
     "@pnpm/network.ca-file": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.1.tgz",
@@ -8373,9 +8699,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "@types/compression": {
@@ -8397,9 +8723,9 @@
       }
     },
     "@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
       "dev": true,
       "requires": {
         "@types/ms": "*"
@@ -8418,14 +8744,15 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "version": "4.17.35",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
+      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "@types/http-cache-semantics": {
@@ -8441,15 +8768,15 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "@types/jsonwebtoken": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
-      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -8474,20 +8801,64 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
     },
     "@types/pg": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
-      "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.10.2.tgz",
+      "integrity": "sha512-MKFs9P6nJ+LAeHLU3V0cODEOgyThJ3OAnmOlsZsxux6sfQs3HRXR5bBn7xG5DjckEFhTAxsXi7k7cd0pCMxpJw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "pg-protocol": "*",
-        "pg-types": "^2.2.0"
+        "pg-types": "^4.0.1"
+      },
+      "dependencies": {
+        "pg-types": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.1.tgz",
+          "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
+          "dev": true,
+          "requires": {
+            "pg-int8": "1.0.1",
+            "pg-numeric": "1.0.2",
+            "postgres-array": "~3.0.1",
+            "postgres-bytea": "~3.0.0",
+            "postgres-date": "~2.0.1",
+            "postgres-interval": "^3.0.0",
+            "postgres-range": "^1.1.1"
+          }
+        },
+        "postgres-array": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+          "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+          "dev": true
+        },
+        "postgres-bytea": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+          "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+          "dev": true,
+          "requires": {
+            "obuf": "~1.1.2"
+          }
+        },
+        "postgres-date": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.0.1.tgz",
+          "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
+          "dev": true
+        },
+        "postgres-interval": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+          "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+          "dev": true
+        }
       }
     },
     "@types/qs": {
@@ -8503,10 +8874,28 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
+    },
+    "@types/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/mime": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+          "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+          "dev": true
+        }
+      }
     },
     "@types/serve-static": {
       "version": "1.15.0",
@@ -8519,21 +8908,21 @@
       }
     },
     "@types/validator": {
-      "version": "13.7.7",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.7.tgz",
-      "integrity": "sha512-jiEw2kTUJ8Jsh4A1K4b5Pkjj9Xz6FktLLOQ36ZVLRkmxFbpTvAV2VRoKMojz8UlZxNg/2dZqzpigH4JYn1bkQg==",
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
-      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
+      "integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/type-utils": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/type-utils": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -8543,53 +8932,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
-      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.0.tgz",
+      "integrity": "sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
-      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.0.tgz",
+      "integrity": "sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0"
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
-      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
+      "integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.57.0",
-        "@typescript-eslint/utils": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
-      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.0.tgz",
+      "integrity": "sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
-      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.0.tgz",
+      "integrity": "sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/visitor-keys": "5.57.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -8598,28 +8987,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
-      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.0.tgz",
+      "integrity": "sha512-ba51uMqDtfLQ5+xHtwlO84vkdjrqNzOnqrnwbMHMRY8Tqeme8C2Q8Fc7LajfGR+e3/4LoYiWXUM6BpIIbHJ4hQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.57.0",
-        "@typescript-eslint/types": "5.57.0",
-        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
-      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.0.tgz",
+      "integrity": "sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/types": "5.60.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -8973,9 +9362,9 @@
       "dev": true
     },
     "c8": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.13.0.tgz",
-      "integrity": "sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.0.tgz",
+      "integrity": "sha512-XHA5vSfCLglAc0Xt8eLBZMv19lgiBSjnb1FLAQgnwkuhJYEonpilhEB4Ea3jPAbm0FhD6VVJrc0z73jPe7JyGQ==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -9559,9 +9948,9 @@
       }
     },
     "dottie": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
-      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
+      "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==",
       "dev": true
     },
     "eastasianwidth": {
@@ -9656,16 +10045,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.37.0.tgz",
-      "integrity": "sha512-NU3Ps9nI05GUoVMxcZx1J8CNR6xOvUT4jAUMH5+z8lpp3aEdPVCImKw6PWG4PY+Vfkpr+jvMpxs/qoE7wq0sPw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.2",
-        "@eslint/js": "8.37.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.43.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -9674,9 +10063,9 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.4.0",
-        "espree": "^9.5.1",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -9684,13 +10073,12 @@
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "globals": "^13.19.0",
-        "grapheme-splitter": "^1.0.4",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -9716,9 +10104,9 @@
           }
         },
         "eslint-scope": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+          "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
@@ -9750,20 +10138,20 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true
     },
     "espree": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.0"
+        "eslint-visitor-keys": "^3.4.1"
       }
     },
     "esquery": {
@@ -10258,6 +10646,12 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -10654,16 +11048,20 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jackspeak": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
+      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "dev": true,
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true
-    },
-    "js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "js-yaml": {
@@ -10697,9 +11095,9 @@
       }
     },
     "json-schema-to-ts": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.9.1.tgz",
+      "integrity": "sha512-8MNpRGERlCUWYeJwsWkMrJ0MWzBz49dfqpG+n9viiIlP4othaahbiaNQZuBzmPxRLUhOv1QJMCzW5WE8nHFGIQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.18.3",
@@ -11256,12 +11654,12 @@
       "dev": true
     },
     "moment-timezone": {
-      "version": "0.5.37",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
-      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
       "dev": true,
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       }
     },
     "ms": {
@@ -11271,16 +11669,16 @@
       "dev": true
     },
     "mysql2": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.2.0.tgz",
-      "integrity": "sha512-0Vn6a9WSrq6fWwvPgrvIwnOCldiEcgbzapVRDAtDZ4cMTxN7pnGqCTx8EG32S/NYXl6AXkdO+9hV1tSIi/LigA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.4.0.tgz",
+      "integrity": "sha512-l952dVcdWVfEIIxMQ1PNSPHYY2htylG7H9ahrQe9lIgDpEMg3hB0S88OhC/loNSZpV8OcywSjgOzjSjEUiuwiQ==",
       "dev": true,
       "requires": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru-cache": "^7.14.1",
+        "lru-cache": "^8.0.0",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
@@ -11296,9 +11694,9 @@
           }
         },
         "lru-cache": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
-          "integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+          "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
           "dev": true
         }
       }
@@ -11448,9 +11846,9 @@
       }
     },
     "npm-check-updates": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.9.0.tgz",
-      "integrity": "sha512-AOAAre4AAPzB5p41E8vbkisx7FypdNCy4mkiF4mMUl6ptOUVkaMGlWVx1eqgmaoraeAnvhyByIGS+4LN7U+XHg==",
+      "version": "16.10.12",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.10.12.tgz",
+      "integrity": "sha512-js/Gg9+5RTyOQZnmFcPswLxf4sK/H5AE/8bl4tkleLJTC1gXhQqqELUFwXqppNvx488aXxN52ZY9k9MSSvEW2A==",
       "dev": true,
       "requires": {
         "chalk": "^5.2.0",
@@ -11463,26 +11861,26 @@
         "globby": "^11.0.4",
         "hosted-git-info": "^5.1.0",
         "ini": "^4.0.0",
+        "js-yaml": "^4.1.0",
         "json-parse-helpfulerror": "^1.0.3",
         "jsonlines": "^0.1.1",
         "lodash": "^4.17.21",
-        "minimatch": "^7.4.3",
+        "minimatch": "^9.0.0",
         "p-map": "^4.0.0",
         "pacote": "15.1.1",
         "parse-github-url": "^1.0.2",
         "progress": "^2.0.3",
-        "prompts-ncu": "^2.5.1",
+        "prompts-ncu": "^3.0.0",
         "rc-config-loader": "^4.1.2",
         "remote-git-tags": "^3.0.0",
-        "rimraf": "^4.4.1",
-        "semver": "^7.3.8",
+        "rimraf": "^5.0.0",
+        "semver": "^7.4.0",
         "semver-utils": "^1.1.4",
         "source-map-support": "^0.5.21",
         "spawn-please": "^2.0.1",
         "strip-json-comments": "^5.0.0",
         "untildify": "^4.0.0",
-        "update-notifier": "^6.0.2",
-        "yaml": "^2.2.1"
+        "update-notifier": "^6.0.2"
       },
       "dependencies": {
         "brace-expansion": {
@@ -11500,16 +11898,27 @@
           "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
           "dev": true
         },
-        "glob": {
-          "version": "9.3.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
-          "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+        "foreground-child": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+          "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "minimatch": "^7.4.1",
-            "minipass": "^4.2.4",
-            "path-scurry": "^1.6.1"
+            "cross-spawn": "^7.0.0",
+            "signal-exit": "^4.0.1"
+          }
+        },
+        "glob": {
+          "version": "10.2.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
+          "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^2.0.3",
+            "minimatch": "^9.0.1",
+            "minipass": "^5.0.0 || ^6.0.2",
+            "path-scurry": "^1.7.0"
           }
         },
         "ini": {
@@ -11519,28 +11928,34 @@
           "dev": true
         },
         "minimatch": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-          "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+          "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "minipass": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
-          "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+          "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
           "dev": true
         },
         "rimraf": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-          "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
+          "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
           "dev": true,
           "requires": {
-            "glob": "^9.2.0"
+            "glob": "^10.2.5"
           }
+        },
+        "signal-exit": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+          "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+          "dev": true
         },
         "strip-json-comments": {
           "version": "5.0.0",
@@ -11701,6 +12116,12 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "dev": true
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
     "on-finished": {
@@ -11881,25 +12302,25 @@
       "dev": true
     },
     "path-scurry": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.3.tgz",
-      "integrity": "sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
       "dev": true,
       "requires": {
-        "lru-cache": "^7.14.1",
-        "minipass": "^4.0.2"
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+          "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
           "dev": true
         },
         "minipass": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
-          "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+          "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
           "dev": true
         }
       }
@@ -11923,24 +12344,32 @@
       "dev": true
     },
     "pg": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.10.0.tgz",
-      "integrity": "sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz",
+      "integrity": "sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==",
       "dev": true,
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
+        "pg-cloudflare": "^1.1.0",
+        "pg-connection-string": "^2.6.0",
         "pg-pool": "^3.6.0",
         "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
     },
+    "pg-cloudflare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.0.tgz",
+      "integrity": "sha512-tGM8/s6frwuAIyRcJ6nWcIvd3+3NmUKIs6OjviIm1HPPFEt5MzQDOTBQyhPWg/m0kCl95M6gA1JaIXtS8KovOA==",
+      "dev": true,
+      "optional": true
+    },
     "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.0.tgz",
+      "integrity": "sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg==",
       "dev": true
     },
     "pg-hstore": {
@@ -11956,6 +12385,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
       "dev": true
     },
     "pg-pool": {
@@ -12026,6 +12461,12 @@
         "xtend": "^4.0.0"
       }
     },
+    "postgres-range": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.3.tgz",
+      "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12061,9 +12502,9 @@
       }
     },
     "prompts-ncu": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-2.5.1.tgz",
-      "integrity": "sha512-Hdd7GgV7b76Yh9FP9HL1D9xqtJCJdVPpiM2vDtuoc8W1KfweJe15gutFYmxkq83ViFaagFM8K0UcPCQ/tZq8bA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-3.0.0.tgz",
+      "integrity": "sha512-qyz9UxZ5MlPKWVhWrCmSZ1ahm2GVYdjLb8og2sg0IPth1KRuhcggHGuijz0e41dkx35p1t1q3GRISGH7QGALFA==",
       "dev": true,
       "requires": {
         "kleur": "^4.0.1",
@@ -12357,9 +12798,9 @@
       "dev": true
     },
     "retry-as-promised": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.3.tgz",
-      "integrity": "sha512-SEvMa4khHvpU/o6zgh7sK24qm6rxVgKnrSyzb5POeDvZx5N9Bf0s5sQsQ4Fl+HjRp0X+w2UzACGfUnXtx6cJ9Q==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA==",
       "dev": true
     },
     "reusify": {
@@ -12399,9 +12840,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -12475,26 +12916,26 @@
       "dev": true
     },
     "sequelize": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.30.0.tgz",
-      "integrity": "sha512-VxQ3gB+isefL8Ic3GDUR6Y8Zwu1ctWNUlffcdSClsLkQ0mwgoLQv3cI3cDwSVn9wZJk0AEwMSm1TYFFRqmcR0A==",
+      "version": "6.32.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.32.1.tgz",
+      "integrity": "sha512-3Iv0jruv57Y0YvcxQW7BE56O7DC1BojcfIrqh6my+IQwde+9u/YnuYHzK+8kmZLhLvaziRT1eWu38nh9yVwn/g==",
       "dev": true,
       "requires": {
-        "@types/debug": "^4.1.7",
-        "@types/validator": "^13.7.1",
-        "debug": "^4.3.3",
-        "dottie": "^2.0.2",
-        "inflection": "^1.13.2",
+        "@types/debug": "^4.1.8",
+        "@types/validator": "^13.7.17",
+        "debug": "^4.3.4",
+        "dottie": "^2.0.4",
+        "inflection": "^1.13.4",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
-        "moment-timezone": "^0.5.35",
-        "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^7.0.3",
-        "semver": "^7.3.5",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.43",
+        "pg-connection-string": "^2.6.0",
+        "retry-as-promised": "^7.0.4",
+        "semver": "^7.5.1",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",
-        "validator": "^13.7.0",
+        "validator": "^13.9.0",
         "wkx": "^0.5.0"
       },
       "dependencies": {
@@ -12990,8 +13431,28 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
@@ -13228,9 +13689,9 @@
       }
     },
     "typescript": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
-      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true
     },
     "underscore": {
@@ -13384,9 +13845,9 @@
       }
     },
     "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "dev": true
     },
     "vary": {
@@ -13494,9 +13955,9 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.0.1.tgz",
-      "integrity": "sha512-QFF+ufAqhoYHvoHdajT/Po7KoXVBPXS2bgjIam5isfWJPfIOnQZ50JtUiVvCv/sjgacf3yRrt2ZKUZ/V4itN4g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^6.1.0",
@@ -13544,6 +14005,17 @@
         }
       }
     },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -13584,12 +14056,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -61,33 +61,33 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@feathersjs/adapter-commons": "^5.0.1",
-    "@feathersjs/commons": "^5.0.1",
-    "@feathersjs/errors": "^5.0.1"
+    "@feathersjs/adapter-commons": "^5.0.6",
+    "@feathersjs/commons": "^5.0.6",
+    "@feathersjs/errors": "^5.0.6"
   },
   "devDependencies": {
-    "@feathersjs/adapter-tests": "^5.0.1",
-    "@feathersjs/express": "^5.0.1",
-    "@feathersjs/feathers": "^5.0.1",
-    "@types/chai": "^4.3.4",
+    "@feathersjs/adapter-tests": "^5.0.6",
+    "@feathersjs/express": "^5.0.6",
+    "@feathersjs/feathers": "^5.0.6",
+    "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.15.11",
-    "@types/pg": "^8.6.6",
-    "@typescript-eslint/eslint-plugin": "^5.57.0",
-    "@typescript-eslint/parser": "^5.57.0",
+    "@types/node": "^20.3.1",
+    "@types/pg": "^8.10.2",
+    "@typescript-eslint/eslint-plugin": "^5.60.0",
+    "@typescript-eslint/parser": "^5.60.0",
     "body-parser": "^1.20.2",
-    "c8": "^7.13.0",
+    "c8": "^8.0.0",
     "chai": "^4.3.7",
-    "eslint": "^8.37.0",
+    "eslint": "^8.43.0",
     "mocha": "^10.2.0",
-    "mysql2": "^3.2.0",
-    "npm-check-updates": "^16.9.0",
-    "pg": "^8.10.0",
+    "mysql2": "^3.4.0",
+    "npm-check-updates": "^16.10.12",
+    "pg": "^8.11.0",
     "pg-hstore": "^2.3.4",
-    "sequelize": "^6.30.0",
+    "sequelize": "^6.32.1",
     "shx": "^0.3.4",
     "sqlite3": "^5.1.6",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.3"
+    "typescript": "^5.1.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { SequelizeAdapter } from './adapter';
 import type { SequelizeAdapterParams } from './declarations';
 import type { Id, NullableId, Paginated, Params, ServiceMethods } from '@feathersjs/feathers';
 import type { PaginationOptions } from '@feathersjs/adapter-commons';
+import type { PaginatedOrArray } from './internal.types';
 
 export * from './declarations'
 export * from './adapter'
@@ -11,10 +12,7 @@ export class SequelizeService<Result = any, Data = Partial<Result>, ServiceParam
   extends SequelizeAdapter<Result, Data, ServiceParams, PatchData>
   implements ServiceMethods<Result | Paginated<Result>, Data, ServiceParams, PatchData>
 {
-  async find (params?: ServiceParams & { paginate?: PaginationOptions }): Promise<Paginated<Result>>
-  async find (params?: ServiceParams & { paginate: false }): Promise<Result[]>
-  async find (params?: ServiceParams): Promise<Paginated<Result> | Result[]>
-  async find (params?: ServiceParams): Promise<Paginated<Result> | Result[]> {
+  async find <P extends ServiceParams & { paginate?: PaginationOptions | false }> (params?: P): Promise<PaginatedOrArray<Result, P>> {
     return this._find(params) as any
   }
 

--- a/src/internal.types.ts
+++ b/src/internal.types.ts
@@ -1,0 +1,7 @@
+import type { Paginated, PaginationOptions } from '@feathersjs/feathers';
+
+export type PaginatedOrArray<R, P = undefined> = P extends { paginate: false }
+  ? R[]
+  : P extends { paginate: PaginationOptions }
+    ? Paginated<R>
+    : (Paginated<R> | R[]);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 
 import Sequelize, { Op } from 'sequelize';
 import errors from '@feathersjs/errors';
+import type { Paginated } from '@feathersjs/feathers';
 import { feathers } from '@feathersjs/feathers';
 import adaptertests from '@feathersjs/adapter-tests';
 
@@ -278,7 +279,7 @@ describe('Feathers Sequelize Service', () => {
       it('allows querying for null values (#45)', async () => {
         const name = 'Null test';
         const person = await people.create({ name });
-        const { data } = await people.find({ query: { age: null } });
+        const { data } = await people.find({ query: { age: null } }) as Paginated<any>;
 
         assert.strictEqual(data.length, 1);
         assert.strictEqual(data[0].name, name);
@@ -293,7 +294,7 @@ describe('Feathers Sequelize Service', () => {
             name: 'Dave',
             __proto__: []
           }
-        });
+        }) as Paginated<any>;
 
         assert.strictEqual(page.data.length, 0);
       });
@@ -304,7 +305,7 @@ describe('Feathers Sequelize Service', () => {
         const { data } = await people.find({
           query:
           { age: { [Sequelize.Op.eq]: 10 } }
-        });
+        }) as Paginated<any>;
 
         assert.strictEqual(data.length, 1);
         assert.strictEqual(data[0].name, name);
@@ -319,7 +320,7 @@ describe('Feathers Sequelize Service', () => {
         const { data } = await people.find({
           query:
           { name: { $like: '%ike%' } }
-        });
+        }) as Paginated<any>;
 
         assert.strictEqual(data.length, 1);
         assert.strictEqual(data[0].name, name);
@@ -441,7 +442,7 @@ describe('Feathers Sequelize Service', () => {
       it('find() returns correct total when using includes for non-raw requests (#137)', async () => {
         const options = { sequelize: { raw: false, include: Order } };
 
-        const result = await people.find(options);
+        const result = await people.find(options) as Paginated<any>;
 
         assert.strictEqual(result.total, 2);
       });
@@ -449,7 +450,7 @@ describe('Feathers Sequelize Service', () => {
       it('find() returns correct total when using includes for raw requests', async () => {
         const options = { sequelize: { include: Order } };
 
-        const result = await people.find(options);
+        const result = await people.find(options) as Paginated<any>;
 
         assert.strictEqual(result.total, 2);
       });
@@ -624,10 +625,10 @@ describe('Feathers Sequelize Service', () => {
       const SCOPE_TO_PENDING = { sequelize: { scope: 'pending' } };
       const person = await people.create(data);
 
-      const staPeople = await people.find(SCOPE_TO_ACTIVE);
+      const staPeople = await people.find(SCOPE_TO_ACTIVE) as Paginated<any>;
       assert.strictEqual(staPeople.data.length, 1);
 
-      const stpPeople = await people.find(SCOPE_TO_PENDING);
+      const stpPeople = await people.find(SCOPE_TO_PENDING) as Paginated<any>;
       assert.strictEqual(stpPeople.data.length, 0);
 
       await people.remove(person.id);


### PR DESCRIPTION
### Problem:
I use the `[key: string]: any` hack for `Params`, as suggested in the migration guide:

```ts
declare module "@feathersjs/feathers" {
  interface Params {
    [key: string]: any;
  }
}
```
see: https://feathersjs.com/guides/migrating.html#typed-params-and-query

When doing this, the `find` params can not be inferred correctly and the function overloads do not work. By using conditional types the ReturnResult is correct.