### PR TITLE
fix: service find method return type

### DIFF
--- a/src/internal.types.ts
+++ b/src/internal.types.ts
@@ -1,7 +1,7 @@
 import type { Paginated, PaginationOptions } from '@feathersjs/feathers';
 
-export type PaginatedOrArray<R, P = undefined> = P extends { paginate: false }
+export type PaginatedOrArray<R, P = undefined> = P extends { paginate?: false }
   ? R[]
   : P extends { paginate: PaginationOptions }
     ? Paginated<R>
-    : (Paginated<R> | R[]);
+    : Paginated<R>;


### PR DESCRIPTION
### Summary
When we use the find method of a service that extends SequelizeService<R, D, SP, PD> the return type is not like expected.
We got an union of paginated type and not paginated type

### Expected behavior
By default the feathers service return a paginated response if we don't specify the field paginated: false.
So the returned type of a find method need to be paginated by default.
#426 426