### PR TITLE
refactor!: perf, restructuring, rm _getOrFind, rm params.$returning, use instance methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ __Options:__
 - `paginate` (*optional*) - A [pagination object](https://docs.feathersjs.com/api/databases/common.html#pagination) containing a `default` and `max` page size
 - `multi` (*optional*) - Allow `create` with arrays and `update` and `remove` with `id` `null` to change multiple items. Can be `true` for all methods or an array of allowed methods (e.g. `[ 'remove', 'create' ]`)
 - `operatorMap` (*optional*) - A mapping from query syntax property names to to [Sequelize secure operators](http://docs.sequelizejs.com/manual/tutorial/querying.html)
-- `operators` (*optional*) - A list of additional query parameters to allow (e..g `[ '$regex', '$geoNear' ]`). Default is the supported `operators`
+- `operators` (*optional*) - An array of additional query operators to allow (e..g `[ '$regex', '$geoNear' ]`). Default is the supported `operators`
+- `filters` (*optional*) - An object of additional query parameters to allow (e..g `{ '$post.id$': true }`).`
 
 ### params.sequelize
 
@@ -115,6 +116,10 @@ app.service('messages').hooks({
 Other options that `params.sequelize` allows you to pass can be found in [Sequelize querying docs](https://sequelize.org/master/manual/model-querying-basics.html).
 Beware that when setting a [top-level `where` property](https://sequelize.org/master/manual/eager-loading.html#complex-where-clauses-at-the-top-level) (usually for querying based on a column on an associated model), the `where` in `params.sequelize` will overwrite your `query`.
 
+This library offers some additional functionality when using `sequelize.returning` in services that support `multi`. The `multi` option allows you to create, patch, and remove multiple records at once. When using `sequelize.returning` with `multi`, the `sequelize.returning` is used to indicate if the method should return any results. This is helpful when updating large numbers of records and you do not need the API (or events) to be bogged down with results.
+
+```js
+
 
 ### operatorMap
 
@@ -137,7 +142,7 @@ Sequelize deprecated string based operators a while ago for security reasons. St
 '$and'
 ```
 
-```
+```js
 // Find all users with name similar to Dav
 app.service('users').find({
   query: {
@@ -316,7 +321,7 @@ Additionally to the [common querying mechanism](https://docs.feathersjs.com/api/
 
 ### Querying a nested column
 
-To query based on a column in an associated model, you can use Sequelize's [nested column syntax](https://sequelize.org/master/manual/eager-loading.html#complex-where-clauses-at-the-top-level) in a query. The nested column syntax is considered an operator by Feathers, and so each such usage has to be [whitelisted](#options-whitelist).
+To query based on a column in an associated model, you can use Sequelize's [nested column syntax](https://sequelize.org/master/manual/eager-loading.html#complex-where-clauses-at-the-top-level) in a query. The nested column syntax is considered a `filter` by Feathers, and so each such usage has to be [whitelisted](#whitelist).
 
 Example:
 ```js
@@ -331,7 +336,7 @@ app.service('users').find({
 });
 ```
 
-For this case to work, you'll need to add '$post.id$' to the service options' ['whitelist' property](#options-whitelist).
+For this case to work, you'll need to add '$post.id$' to the service options' ['filters' property](#whitelist).
 
 ## Working with Sequelize Model instances
 
@@ -349,7 +354,7 @@ It is highly recommended to use `raw` queries, which is the default. However, th
 1. Use the new `hydrate` hook in the "after" phase:
 
     ```js
-    const hydrate = require('feathers-sequelize/hooks/hydrate');
+    const { hydrate } = require('feathers-sequelize');
     hooks.after.find = [hydrate()];
 
     // Or, if you need to include associated models, you can do the following:
@@ -637,6 +642,12 @@ Copyright (c) 2022
 
 Licensed under the [MIT license](LICENSE).
 
+### whitelist
+
+The `whitelist` property is no longer, you should use `filters` instead. Checkout the migration guide below.
+
+> Feathers v5 introduces a convention for `options.operators` and `options.filters`. The way feathers-sequelize worked in previous version is not compatible with these conventions. Please read https://dove.feathersjs.com/guides/migrating.html#custom-filters-operators.
+
 ## Migrate to Feathers v5 (dove)
 
 There are several breaking changes for feathers-sequelize in Feathers v5. This guide will help you to migrate your existing Feathers v4 application to Feathers v5.
@@ -689,7 +700,3 @@ app.use('/messages', new SequelizeService({
   }
 }));
 ```
-
-### whitelist
-
-> Feathers v5 introduces a convention for `options.operators` and `options.filters`. The way feathers-sequelize worked in previous version is not compatible with these conventions. Please read https://dove.feathersjs.com/guides/migrating.html#custom-filters-operators.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A [Feathers](https://feathersjs.com) database adapter for [Sequelize](http://seq
   - [Querying a nested column](#querying-a-nested-column)
 - [Working with Sequelize Model instances](#working-with-sequelize-model-instances)
 - [Validation](#validation)
+- [Errors](#errors)
 - [Testing sequelize queries in isolation](#testing-sequelize-queries-in-isolation)
   - [1. Build a test file](#1-build-a-test-file)
   - [2. Integrate the query using a "before" hook](#2-integrate-the-query-using-a-before-hook)
@@ -162,7 +163,7 @@ By default, all `feathers-sequelize` operations will return `raw` data (using `r
  - associated data loads a bit differently
  - ...and several other issues that one might not expect
 
-Don't worry! The solution is easy. Please read the guides about [working with model instances](#working-with-sequelize-model-instances).
+Don't worry! The solution is easy. Please read the guides about [working with model instances](#working-with-sequelize-model-instances). You can also pass `{ raw: true/false}` in `params.sequelize` to change the behavior per service call.
 
 ### Working with MSSQL
 
@@ -313,8 +314,6 @@ For more information, follow up up in the [Sequelize documentation for associati
 
 Additionally to the [common querying mechanism](https://docs.feathersjs.com/api/databases/querying.html) this adapter also supports all [Sequelize query operators](http://docs.sequelizejs.com/manual/tutorial/querying.html).
 
-> **Note**: This adapter supports an additional `$returning` parameter for patch and remove queries. By setting `params.$returning = false` it will disable feathers and sequelize from returning what was changed, so mass updates can be done without overwhelming node and/or clients.
-
 ### Querying a nested column
 
 To query based on a column in an associated model, you can use Sequelize's [nested column syntax](https://sequelize.org/master/manual/eager-loading.html#complex-where-clauses-at-the-top-level) in a query. The nested column syntax is considered an operator by Feathers, and so each such usage has to be [whitelisted](#options-whitelist).
@@ -376,13 +375,29 @@ It is highly recommended to use `raw` queries, which is the default. However, th
 
 Sequelize by default gives you the ability to [add validations at the model level](http://docs.sequelizejs.com/en/latest/docs/models-definition/#validations). Using an error handler like the one that [comes with Feathers](https://github.com/feathersjs/feathers-errors/blob/master/src/error-handler.js) your validation errors will be formatted nicely right out of the box!
 
+## Errors
+
+Errors do not contain Sequelize specific information. The original Sequelize error can be retrieved on the server via:
+
+```js
+const { ERROR } = require('feathers-sequelize');
+
+try {
+  await sequelizeService.doSomethign();
+} catch(error) {
+  // error is a FeathersError
+  // Safely retrieve the Sequelize error
+  const sequelizeError = error[ERROR];
+}
+```
+
 ## Testing sequelize queries in isolation
 
 If you wish to use some of the more advanced features of sequelize, you should first test your queries in isolation (without feathers). Once your query is working, you can integrate it into your feathers app.
 
 ### 1. Build a test file
 
-Creat a temporary file in your project root like this:
+Create a temporary file in your project root like this:
 
 ```js
 // test.js
@@ -615,32 +630,6 @@ In the unfortunate case where you must revert your app to a previous state, it i
 1. Undo your migrations one at a time until the db is in the correct state
 1. Revert your code back to the previous state
 1. Start your app
-
-### Migrating
-
-`feathers-sequelize` 4.0.0 comes with important security and usability updates.
-
-> __Important:__ For general migration information to the new database adapter functionality see [crow.docs.feathersjs.com/migrating.html#database-adapters](https://crow.docs.feathersjs.com/migrating.html#database-adapters).
-
-The following breaking changes have been introduced:
-
-- All methods now take `params.sequelize` into account
-- All methods allow additional query parameters
-- Multiple updates are disabled by default (see the `multi` option)
-- Upgraded to secure Sequelize operators (see the [operators](#operators) option)
-- Errors no longer contain Sequelize specific information. The original Sequelize error can be retrieved on the server via:
-
-```js
-const { ERROR } = require('feathers-sequelize');
-
-try {
-  await sequelizeService.doSomethign();
-} catch(error) {
-  // error is a FeathersError
-  // Safely retrieve the Sequelize error
-  const sequelizeError = error[ERROR];
-}
-```
 
 ## License
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -8,23 +8,21 @@ import { errorHandler, getOrder, isPlainObject } from './utils';
 import { Op } from 'sequelize';
 import type { CreateOptions, FindOptions, Model } from 'sequelize';
 
-const defaultOpMap = () => {
-  return {
-    $eq: Op.eq,
-    $ne: Op.ne,
-    $gte: Op.gte,
-    $gt: Op.gt,
-    $lte: Op.lte,
-    $lt: Op.lt,
-    $in: Op.in,
-    $nin: Op.notIn,
-    $like: Op.like,
-    $notLike: Op.notLike,
-    $iLike: Op.iLike,
-    $notILike: Op.notILike,
-    $or: Op.or,
-    $and: Op.and
-  };
+const defaultOperatorMap = {
+  $eq: Op.eq,
+  $ne: Op.ne,
+  $gte: Op.gte,
+  $gt: Op.gt,
+  $lte: Op.lte,
+  $lt: Op.lt,
+  $in: Op.in,
+  $nin: Op.notIn,
+  $like: Op.like,
+  $notLike: Op.notLike,
+  $iLike: Op.iLike,
+  $notILike: Op.notILike,
+  $or: Op.or,
+  $and: Op.and
 };
 
 const defaultFilters = () => {
@@ -56,7 +54,7 @@ export class SequelizeAdapter<
     }
 
     const operatorMap = {
-      ...defaultOpMap(),
+      ...defaultOperatorMap,
       ...options.operatorMap
     };
     const operators = Object.keys(operatorMap);

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -254,6 +254,16 @@ export class SequelizeAdapter<
 
     try {
       if (paginate && paginate.default) {
+        if (q.limit === 0) {
+          const total = await Model.count(q);
+          return {
+            total,
+            limit: q.limit,
+            skip: q.offset || 0,
+            data: [] as Result[]
+          }
+        }
+
         const result = await Model.findAndCountAll(q);
 
         return {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -492,7 +492,7 @@ export class SequelizeAdapter<
 
     const instance = await Model
       .build(values, { isNewRecord: false })
-      .update(values, sequelize)
+      .update(_.omit(values, this.id), sequelize)
       .catch(errorHandler);
 
     if (isPresent(sequelize.include)) {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -257,7 +257,10 @@ export class SequelizeAdapter<
     try {
       if (paginate && paginate.default) {
         if (q.limit === 0) {
-          const total = await Model.count(q);
+          const total = await Model.count({
+            ...q,
+            attributes: undefined
+          });
           return {
             total,
             limit: q.limit,

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -395,21 +395,23 @@ export class SequelizeAdapter<
       const selected = isPresent(sequelize.attributes);
 
       if (instances) {
-        const sortedInstances: Model[] = [];
-        const unsortedInstances: Model[] = [];
+        if (isPresent(params?.query?.$sort)) {
+          const sortedInstances: Model[] = [];
+          const unsortedInstances: Model[] = [];
 
-        current.forEach((item: any) => {
-          const id = item[this.id];
-          // @ts-ignore
-          const instance = instances.find(instance => instance[this.id] === id);
-          if (instance) {
-            sortedInstances.push(instance);
-          } else {
-            unsortedInstances.push(item);
-          }
-        });
+          current.forEach((item: any) => {
+            const id = item[this.id];
+            // @ts-ignore
+            const instance = instances.find(instance => instance[this.id] === id);
+            if (instance) {
+              sortedInstances.push(instance);
+            } else {
+              unsortedInstances.push(item);
+            }
+          });
 
-        instances = [...sortedInstances, ...unsortedInstances];
+          instances = [...sortedInstances, ...unsortedInstances];
+        }
 
         if (sequelize.raw) {
           const result = instances.map((instance) => {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -503,16 +503,17 @@ export class SequelizeAdapter<
       });
     }
 
-    if (isPresent(sequelize.attributes)) {
-      const values = select(instance.toJSON())
-      if (sequelize.raw) {
-        return values;
+    if (sequelize.raw) {
+      const result = instance.toJSON();
+      if (isPresent(sequelize.attributes)) {
+        return select(result);
       }
-      return Model.build(values, { isNewRecord: false });
+      return result;
     }
 
-    if (sequelize.raw) {
-      return instance.toJSON();
+    if (isPresent(sequelize.attributes)) {
+      const result = select(instance.toJSON())
+      return Model.build(result, { isNewRecord: false });
     }
 
     return instance as Result;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -25,17 +25,15 @@ const defaultOperatorMap = {
   $and: Op.and
 };
 
-const defaultFilters = () => {
-  return {
-    $returning: (value: any) => {
-      if (value === true || value === false || value === undefined) {
-        return value;
-      }
+const defaultFilters = {
+  $returning: (value: any) => {
+    if (value === true || value === false || value === undefined) {
+      return value;
+    }
 
-      throw new BadRequest('Invalid $returning filter value');
-    },
-    $and: true as const
-  }
+    throw new BadRequest('Invalid $returning filter value');
+  },
+  $and: true as const
 }
 
 export class SequelizeAdapter<
@@ -72,7 +70,7 @@ export class SequelizeAdapter<
       : 'id';
 
     const filters = {
-      ...defaultFilters(),
+      ...defaultFilters,
       ...options.filters
     };
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -226,13 +226,13 @@ export class SequelizeAdapter<
   async _getOrFind (id: NullableId, _params: ServiceParams) {
     const params = _params || {} as ServiceParams;
     if (id === null) {
-      return await this._find({
+      return this._find({
         ...params,
         paginate: false
       });
     }
 
-    return await this._get(id, params);
+    return this._get(id, params);
   }
 
 
@@ -456,7 +456,10 @@ export class SequelizeAdapter<
       .catch(errorHandler);
 
     if (isPresent(sequelize.include)) {
-      return await this._get(id, params);
+      return this._get(id, {
+        ...params,
+        query: { $select: params.query?.$select }
+      });
     }
 
     if (sequelize.raw) {
@@ -507,7 +510,10 @@ export class SequelizeAdapter<
       .catch(errorHandler);
 
     if (isPresent(sequelize.include)) {
-      return await this._get(id, params);
+      return this._get(id, {
+        ...params,
+        query: { $select: params.query?.$select }
+      });
     }
 
     if (isPresent(sequelize.attributes)) {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -417,10 +417,7 @@ export class SequelizeAdapter<
 
     const result = await this._get(id, {
       ...params,
-      query: {
-        [this.id]: id,
-        $select: params?.query?.$select
-      }
+      query: { $select: params?.query?.$select  }
     });
 
     return result

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -188,12 +188,8 @@ export class SequelizeAdapter<
       offset: filters.$skip,
       attributes: filters.$select,
       distinct: true,
-      returning:  typeof params.sequelize?.returning === 'boolean'
-        ? params.sequelize.returning
-        : true,
-      raw: typeof params.sequelize?.raw === 'boolean'
-        ? params.sequelize.raw
-        : this.raw,
+      returning: true,
+      raw: this.raw,
       ...params.sequelize
     };
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -173,7 +173,7 @@ export class SequelizeAdapter<
 
   paramsToAdapter (id: NullableId, _params?: ServiceParams): FindOptions {
     const params = _params || {} as ServiceParams;
-    if (id) {
+    if (id !== null) {
       let { query: where } = this.filterQuery(params);
 
       // explicitly set id

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -436,10 +436,9 @@ export class SequelizeAdapter<
       sequelize: { ...params.sequelize, raw: false }
     }) as Model;
 
-    instance.set(values)
-
     await instance
-      .save(sequelize)
+      .set(values)
+      .update(values, sequelize)
       .catch(errorHandler);
 
     if (isPresent(sequelize.include)) {
@@ -493,7 +492,7 @@ export class SequelizeAdapter<
 
     const instance = await Model
       .build(values, { isNewRecord: false })
-      .update(_.omit(values, this.id), sequelize)
+      .update(values, sequelize)
       .catch(errorHandler);
 
     if (isPresent(sequelize.include)) {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -395,7 +395,7 @@ export class SequelizeAdapter<
       const selected = isPresent(sequelize.attributes);
 
       if (instances) {
-        if (isPresent(params?.query?.$sort)) {
+        if (isPresent(params.query?.$sort)) {
           const sortedInstances: Model[] = [];
           const unsortedInstances: Model[] = [];
 
@@ -453,8 +453,12 @@ export class SequelizeAdapter<
       sequelize: { ...params.sequelize, raw: false }
     }) as Model;
 
+    Object.keys(values).forEach(key => {
+      instance.set(key, values[key]);
+    });
+
     await instance
-      .update(values, sequelize)
+      .save(sequelize)
       .catch(errorHandler);
 
     if (isPresent(sequelize.include)) {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -204,6 +204,7 @@ export class SequelizeAdapter<
 
     const q: FindOptions = {
       where,
+      limit: 1,
       raw: this.raw,
       ...params.sequelize
     };

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -219,27 +219,6 @@ export class SequelizeAdapter<
     return sequelize;
   }
 
-  /**
-   * returns either the model instance / jsonified object for an id or all unpaginated
-   * items for `params` if id is null
-   *
-   * @deprecated Use `_get` or `_find` instead. `_getOrFind` will be removed in a future release.
-   */
-  async _getOrFind (id: Id, _params?: ServiceParams): Promise<Result>
-  async _getOrFind (id: null, _params?: ServiceParams): Promise<Result[]>
-  async _getOrFind (id: NullableId, _params: ServiceParams) {
-    const params = _params || {} as ServiceParams;
-    if (id === null) {
-      return this._find({
-        ...params,
-        paginate: false
-      });
-    }
-
-    return this._get(id, params);
-  }
-
-
   async _find (params?: ServiceParams & { paginate?: PaginationOptions }): Promise<Paginated<Result>>
   async _find (params?: ServiceParams & { paginate: false }): Promise<Result[]>
   async _find (params?: ServiceParams): Promise<Paginated<Result> | Result[]>

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -9,7 +9,6 @@ export interface SequelizeAdapterOptions extends AdapterServiceOptions {
 
 export interface SequelizeAdapterParams<Q = AdapterQuery> extends AdapterParams<Q, Partial<SequelizeAdapterOptions>> {
   sequelize?: any // FindOptions | CreateOptions | BulkCreateOptions
-  $returning?: boolean
 }
 
 export type HydrateOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './declarations'
 export * from './adapter'
 export * from './hooks';
 export { ERROR, errorHandler } from './utils';
+
 export class SequelizeService<Result = any, Data = Partial<Result>, ServiceParams extends Params<any> = SequelizeAdapterParams, PatchData = Partial<Data>>
   extends SequelizeAdapter<Result, Data, ServiceParams, PatchData>
   implements ServiceMethods<Result | Paginated<Result>, Data, ServiceParams, PatchData>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import type { FeathersError } from '@feathersjs/errors';
 import { BadRequest, Forbidden, GeneralError, NotFound, Timeout, Unavailable } from '@feathersjs/errors';
 import type { BaseError } from 'sequelize';
 export const ERROR = Symbol('feathers-sequelize/error');
+
 const wrap = (error: FeathersError, original: BaseError) => Object.assign(error, { [ERROR]: original });
 
 export const errorHandler = (error: any) => {
@@ -47,11 +48,11 @@ export const getOrder = (sort: Record<string, any> = {}) => Object.keys(sort).re
   return order;
 }, []);
 
-export const isPlainObject = (obj: any) => {
-  return obj && obj.constructor === {}.constructor;
+export const isPlainObject = (obj: any): boolean => {
+  return !!obj && obj.constructor === {}.constructor;
 };
 
-export const isPresent = (obj: any) => {
+export const isPresent = (obj: any): boolean => {
   if (Array.isArray(obj)) {
     return obj.length > 0;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,3 +50,13 @@ export const getOrder = (sort: Record<string, any> = {}) => Object.keys(sort).re
 export const isPlainObject = (obj: any) => {
   return obj && obj.constructor === {}.constructor;
 };
+
+export const isEmpty = (obj: any) => {
+  if (Array.isArray(obj)) {
+    return obj.length === 0;
+  }
+  if (isPlainObject(obj)) {
+    return Object.keys(obj).length === 0;
+  }
+  return !obj;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,12 +51,12 @@ export const isPlainObject = (obj: any) => {
   return obj && obj.constructor === {}.constructor;
 };
 
-export const isEmpty = (obj: any) => {
+export const isPresent = (obj: any) => {
   if (Array.isArray(obj)) {
-    return obj.length === 0;
+    return obj.length > 0;
   }
   if (isPlainObject(obj)) {
-    return Object.keys(obj).length === 0;
+    return Object.keys(obj).length > 0;
   }
-  return !obj;
+  return !!obj;
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -403,6 +403,12 @@ describe('Feathers Sequelize Service', () => {
         assert.strictEqual(updatedPerson.name, updateName);
       });
 
+      it('does not use $skip in get()', async () => {
+        const result = await people.get(kirsten.id, { query: { $skip: 10 } });
+
+        assert.strictEqual(result.id, kirsten.id);
+      })
+
       it('filterQuery does not convert dates and symbols', () => {
         const mySymbol = Symbol('test');
         const date = new Date();
@@ -449,7 +455,7 @@ describe('Feathers Sequelize Service', () => {
           .then(() => people.remove(null, { query: {} }))
       );
 
-      it('find() returns correct total when using includes for non-raw requests (#137)', async () => {
+      it('find() returns correct total when using includes for non-raw requests #137', async () => {
         const options = { sequelize: { raw: false, include: Order } };
 
         const result = await people.find(options) as Paginated<any>;
@@ -670,7 +676,7 @@ describe('Feathers Sequelize Service', () => {
       });
     });
 
-    it('can set the scope of an operation#130', async () => {
+    it('can set the scope of an operation #130', async () => {
       const people = app.service('people');
       const data = { name: 'Active', status: 'active' };
       const SCOPE_TO_ACTIVE = { sequelize: { scope: 'active' } };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,8 @@ import pg from 'pg';
 import assert from 'assert';
 import { expect } from 'chai';
 
+console.log('DATABASE_URL', process.env.DB);
+
 import Sequelize, { Op } from 'sequelize';
 import errors from '@feathersjs/errors';
 import type { Paginated } from '@feathersjs/feathers';
@@ -85,7 +87,7 @@ const testSuite = adaptertests([
 ]);
 
 // The base tests require the use of Sequelize.BIGINT to avoid 'out of range errors'
-// Unfortunetly BIGINT's are serialized as Strings:
+// Unfortunately BIGINT's are serialized as Strings:
 // https://github.com/sequelize/sequelize/issues/1774
 pg.defaults.parseInt8 = true;
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -704,16 +704,37 @@ describe('Feathers Sequelize Service', () => {
         await people.remove(results[1].id);
       });
 
+      it('create() with returning=false returns empty array', async () => {
+        const response1 = await people.create({ name: 'delete' }, {
+          sequelize: { returning: false }
+        });
+        const response2 = await people.create([{ name: 'delete' }], {
+          sequelize: { returning: false }
+        });
+
+        expect(response1).to.deep.equal([]);
+        expect(response2).to.deep.equal([]);
+
+        await people.remove(null, { query: { name: 'delete' } });
+      });
+
       it('patch() returns a model instance', async () => {
         const instance = await people.patch(david.id, { name: 'Sarah' });
 
         expect(instance).to.be.an.instanceOf(Model);
       });
 
-      it('patch() with $returning=false returns empty array', async () => {
-        const response = await people.patch(david.id, { name: 'Sarah' }, { $returning: false });
+      it('patch() with returning=false returns empty array', async () => {
+        const response1 = await people.patch(david.id, { name: 'Sarah' }, {
+          sequelize: { returning: false }
+        });
+        const response2 = await people.patch(null, { name: 'Sarah' }, {
+          query: { name: 'Sarah' },
+          sequelize: { returning: false }
+        });
 
-        expect(response).to.deep.equal([]);
+        expect(response1).to.deep.equal([]);
+        expect(response2).to.deep.equal([]);
       });
 
       it('update() returns a model instance', async () => {
@@ -728,10 +749,18 @@ describe('Feathers Sequelize Service', () => {
         expect(instance).to.be.an.instanceOf(Model);
       });
 
-      it('remove() with $returning=false returns empty array', async () => {
-        const response = await people.remove(david.id, { $returning: false });
+      it('remove() with returning=false returns empty array', async () => {
+        const response1 = await people.remove(david.id, {
+          sequelize: { returning: false }
+        });
+        david = await people.create({ name: 'David' });
+        const response2 = await people.remove(null, {
+          query: { name: 'David' },
+          sequelize: { returning: false }
+        });
 
-        expect(response).to.deep.equal([]);
+        expect(response1).to.deep.equal([]);
+        expect(response2).to.deep.equal([]);
       });
     });
 
@@ -916,12 +945,29 @@ describe('Feathers Sequelize Service', () => {
         expect(instance).to.be.an.instanceof(Model);
       });
 
-      it('patch() with $returning=false returns empty array', async () => {
-        const params = getExtraParams({ $returning: false });
-        const response = await people.patch(david.id, { name: 'Sarah' }, params);
-        expect(params.sequelize.getModelCalls.count).to.gte(1);
+      it('create() with returning=false returns empty array', async () => {
+        const params = getExtraParams({}, { returning: false });
+        const response1 = await people.create({ name: 'delete' }, params);
+        const response2 = await people.create([{ name: 'delete' }], params);
 
-        expect(response).to.deep.equal([]);
+        expect(response1).to.deep.equal([]);
+        expect(response2).to.deep.equal([]);
+
+        await people.remove(null, { ...params, query: { name: 'delete' } });
+      });
+
+      it('patch() with returning=false returns empty array', async () => {
+        const params = getExtraParams({}, { returning: false });
+        const response1 = await people.patch(david.id, { name: 'Sarah' },
+          params
+        );
+        const response2 = await people.patch(null, { name: 'Sarah' }, {
+          query: { name: 'Sarah' },
+          sequelize: { ...params.sequelize, returning: false }
+        });
+
+        expect(response1).to.deep.equal([]);
+        expect(response2).to.deep.equal([]);
       });
 
       it('update() returns a model instance', async () => {
@@ -939,12 +985,17 @@ describe('Feathers Sequelize Service', () => {
         expect(instance).to.be.an.instanceof(Model);
       });
 
-      it('remove() with $returning=false returns empty array', async () => {
-        const params = getExtraParams({ $returning: false });
-        const response = await people.remove(david.id, params);
-        expect(params.sequelize.getModelCalls.count).to.gte(1);
+      it('remove() with returning=false returns empty array', async () => {
+        const params = getExtraParams({}, { returning: false });
+        const response1 = await people.remove(david.id, params);
+        david = await people.create({ name: 'David' }, params);
+        const response2 = await people.remove(null, {
+          query: { name: 'David' },
+          sequelize: { ...params.sequelize, returning: false }
+        });
 
-        expect(response).to.deep.equal([]);
+        expect(response1).to.deep.equal([]);
+        expect(response2).to.deep.equal([]);
       });
     });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -520,7 +520,7 @@ describe('Feathers Sequelize Service', () => {
         });
 
         delete current.updatedAt;
-        delete result.updatedAt
+        delete result.updatedAt;
 
         assert.deepStrictEqual(result, { ...current, ...data });
       });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -275,8 +275,6 @@ describe('Feathers Sequelize Service', () => {
         await people.create({ name });
         const { data } = await people.find({ query: { age: null } }) as Paginated<any>;
 
-        console.log(data);
-
         assert.strictEqual(data.length, 1);
         assert.strictEqual(data[0].name, name);
         assert.strictEqual(data[0].age, null);
@@ -474,6 +472,26 @@ describe('Feathers Sequelize Service', () => {
         expect(result).to.have.property('orders.id');
       });
 
+      it('patch() includes associations and query', async () => {
+        const params = { sequelize: { include: Order } };
+        const data = { name: 'Patched' };
+
+        const current = await people.get(kirsten.id, params);
+
+        const result = await people.patch(kirsten.id, data, {
+          query: { name: current.name },
+          ...params
+        });
+
+        delete current.updatedAt;
+        // @ts-ignore
+        delete result.updatedAt
+
+        console.log(result, { ...current, ...data })
+
+        assert.deepStrictEqual(result, { ...current, ...data });
+      });
+
       it('update() includes associations', async () => {
         const params = { sequelize: { include: Order } };
         const data = { name: 'Updated' };
@@ -481,6 +499,26 @@ describe('Feathers Sequelize Service', () => {
         const result = await people.update(kirsten.id, data, params);
 
         expect(result).to.have.property('orders.id');
+      });
+
+      it('update() includes associations and query', async () => {
+        const params = { sequelize: { include: Order } };
+        const data = { name: 'Updated' };
+
+        const current = await people.get(kirsten.id, params);
+
+        const result = await people.update(kirsten.id, {
+          ...current,
+          ...data
+        }, {
+          query: { name: current.name },
+          ...params
+        });
+
+        delete current.updatedAt;
+        delete result.updatedAt
+
+        assert.deepStrictEqual(result, { ...current, ...data });
       });
 
       it('remove() includes associations', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -487,8 +487,6 @@ describe('Feathers Sequelize Service', () => {
         // @ts-ignore
         delete result.updatedAt
 
-        console.log(result, { ...current, ...data })
-
         assert.deepStrictEqual(result, { ...current, ...data });
       });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -148,4 +148,39 @@ describe('Feathers Sequelize Utils', () => {
       ]);
     });
   });
+
+  describe('isPlainObject', () => {
+    it('returns true for plain objects', () => {
+      expect(utils.isPlainObject({})).to.equal(true);
+      expect(utils.isPlainObject({ a: 1 })).to.equal(true);
+    });
+
+    it('returns false for non-plain objects', () => {
+      expect(utils.isPlainObject([])).to.equal(false);
+      expect(utils.isPlainObject(new Date())).to.equal(false);
+      expect(utils.isPlainObject(null)).to.equal(false);
+      expect(utils.isPlainObject(undefined)).to.equal(false);
+      expect(utils.isPlainObject('')).to.equal(false);
+      expect(utils.isPlainObject(1)).to.equal(false);
+      expect(utils.isPlainObject(true)).to.equal(false);
+    });
+  });
+
+  describe('isPresent', () => {
+    it('returns true for present objects', () => {
+      expect(utils.isPresent({ a: 1 })).to.equal(true);
+      expect(utils.isPresent([1])).to.equal(true);
+      expect(utils.isPresent('a')).to.equal(true);
+      expect(utils.isPresent(1)).to.equal(true);
+      expect(utils.isPresent(true)).to.equal(true);
+    });
+
+    it('returns false for non-present objects', () => {
+      expect(utils.isPresent({})).to.equal(false);
+      expect(utils.isPresent([])).to.equal(false);
+      expect(utils.isPresent('')).to.equal(false);
+      expect(utils.isPresent(null)).to.equal(false);
+      expect(utils.isPresent(undefined)).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
Included in this PR:

### BREAKING:
- refactor!: renamed `service.applyScope()` to `service.ModelWithScope()`
- refactor!: removed `service._getOrFind()` method. Use `service._get()` or `service._find()` directly.
- refactor!: removed `params.$returning = false`. Use `params.sequelize.returning = false` instead (for bulk operations).
- refactor!: single `patch` and `remove` functions now use single `instance.update` instead of static `Model.update`. So the single [sequelize hooks](https://sequelize.org/docs/v6/other-topics/hooks/) get called.

### Other changes
- perf: `paramsToAdapter`: if `id` is not null, add `id` to the query intelligently.
   - if `query[this.id] === id` we can skip adding the id again
   - if `!(this.id in query)` we can just set `query[this.id] = id` safely
   - else proceed as before. `query[this.id]` is guaranteed to be something.  check for `$and` and add to `$and`
- perf: `patch` and `remove`: Don't use `[this.id]: { [this.Op.in]: ids }` if `ids.length === 1`. Use `[this.id]: ids[0]` instead
- perf: `patch` and `remove`: If the first `_find` call does not return any items (`ids.length === 0`), return instantly
- refactor: `Object.assign` to object spread
- refactor: deprecate `service.Op`. Use direct import from sequelize instead: `import { Op } from 'sequelize';`

Issues:
- closes #384 
- closes #382 

This is a coproduction of @DaddyWarbucks & @fratzinger. Thanks @DaddyWarbucks. This was fun!