### PR TITLE
feature: Support `schema` in params.sequelize

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -114,6 +114,15 @@ export class SequelizeAdapter<
 
   ModelWithScope (params: ServiceParams) {
     return this.applyScope(params);
+  };
+
+  ModelWithSequelizeParams (params: ServiceParams) {
+    let Model = this.getModel(params)
+
+    if (params?.sequelize?.scope) Model = Model.scope(params.sequelize.scope)
+    if (params?.sequelize?.schema) Model = Model.schema(params.sequelize.schema)
+
+    return Model
   }
 
   convertOperators (q: any): Query {
@@ -231,7 +240,7 @@ export class SequelizeAdapter<
   async _find (params: ServiceParams = {} as ServiceParams): Promise<Paginated<Result> | Result[]> {
     const { paginate } = this.filterQuery(params);
 
-    const Model = this.ModelWithScope(params);
+    const Model = this.ModelWithSequelizeParams(params);
     const q = this.paramsToAdapter(null, params);
 
     try {
@@ -253,7 +262,7 @@ export class SequelizeAdapter<
   }
 
   async _get (id: Id, params: ServiceParams = {} as ServiceParams): Promise<Result> {
-    const Model = this.ModelWithScope(params);
+    const Model = this.ModelWithSequelizeParams(params);
     const q = this.paramsToAdapter(id, params);
 
     // findById calls findAll under the hood. We use findAll so that
@@ -291,7 +300,7 @@ export class SequelizeAdapter<
       returning: true
     }, options, { raw: ignoreSetters });
     const isArray = Array.isArray(data);
-    const Model = this.ModelWithScope(params);
+    const Model = this.ModelWithSequelizeParams(params);
 
     try {
       const result = isArray
@@ -318,7 +327,7 @@ export class SequelizeAdapter<
       throw new MethodNotAllowed('Can not patch multiple entries')
     }
 
-    const Model = this.ModelWithScope(params);
+    const Model = this.ModelWithSequelizeParams(params);
 
     // Get a list of ids that match the id/query. Overwrite the
     // $select because only the id is needed for this idList
@@ -404,7 +413,7 @@ export class SequelizeAdapter<
       throw new MethodNotAllowed('Can not remove multiple entries')
     }
 
-    const Model = this.ModelWithScope(params);
+    const Model = this.ModelWithSequelizeParams(params);
 
     const findParams = { ...params };
     if (params.$returning === false) {

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -1,21 +1,24 @@
 import { Sequelize } from 'sequelize';
 
-export default (DB?: 'postgres' | 'mysql') => {
+export default (DB?: 'postgres' | 'mysql', schema = 'default') => {
   if (DB === 'postgres') {
     return new Sequelize('sequelize', 'postgres', 'password', {
       host: 'localhost',
-      dialect: 'postgres'
+      dialect: 'postgres',
+      schema
     });
   } else if (DB === 'mysql') {
     return new Sequelize('sequelize', 'root', '', {
       host: '127.0.0.1',
-      dialect: 'mysql'
+      dialect: 'mysql',
+      schema
     });
   } else {
     return new Sequelize('sequelize', '', '', {
       dialect: 'sqlite',
       storage: './db.sqlite',
-      logging: false
+      logging: false,
+      schema
     });
   }
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -633,6 +633,45 @@ describe('Feathers Sequelize Service', () => {
 
       await people.remove(person.id);
     });
+
+    it('can set the schema', async () => {
+      const ModelAlt = sequelize.define('people', {
+        name: {
+          type: Sequelize.STRING,
+          allowNull: false
+        },
+        age: {
+          type: Sequelize.INTEGER
+        },
+        created: {
+          type: Sequelize.BOOLEAN
+        },
+        time: {
+          type: Sequelize.BIGINT
+        },
+        status: {
+          type: Sequelize.STRING,
+          defaultValue: 'pending'
+        }
+      }, {
+        schema: 'alternative',
+        freezeTableName: true
+      });
+      await ModelAlt.sync({ force: true })
+
+      const people= app.service('people')
+      const data = { name: 'Jiri Schema' };
+      const SCHEMA_DEFAULT = { sequelize: { schema: 'default' } };
+      const SCHEMA_ALTERNATIVE = { sequelize: { schema: 'alternative' } };
+      const personDefault = await people.create(data, SCHEMA_DEFAULT);
+      const personAlternative = await people.create(data, SCHEMA_ALTERNATIVE);
+
+      assert.ok(personDefault)
+      assert.ok(personAlternative)
+
+      await people.remove(personDefault.id, SCHEMA_DEFAULT);
+      await people.remove(personAlternative.id, SCHEMA_ALTERNATIVE);
+    })
   });
 
   describe('ORM functionality', () => {


### PR DESCRIPTION
- [x] Tell us about the problem your pull request is solving.

This PR adds support for underlying Sequelize's `schema` method on the Model, which allows to specify DB schema per-request. This enables feathers-sequelize to be used in schema-divided multitenant systems. 

- [x] Are there any open issues that are related to this?

Yep, #433. 

- [x] Is this PR dependent on PRs in other repos?

No.

