### PR TITLE
fix: multi patch raw false

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,6 +7,10 @@ env:
   POSTGRES_PASSWORD: password
   POSTGRES_DB: sequelize
 
+  MYSQL_USER: sequelize
+  MYSQL_DATABASE: sequelize
+  MYSQL_PASSWORD: password
+
 jobs:
   build:
 
@@ -24,10 +28,27 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+      mysql:
+        image: mysql:8.4
+        env:
+          # The MySQL docker container requires these environment variables to be set
+          # so we can create and migrate the test database.
+          # See: https://hub.docker.com/_/mysql
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+          MYSQL_USER: ${{ env.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+        ports:
+          # Opens port 3306 on service container and host
+          # https://docs.github.com/en/actions/using-containerized-services/about-service-containers
+          - 3306:3306
+          # Before continuing, verify the mysql container is reachable from the ubuntu host
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries 5
+
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        database: ['sqlite', 'postgres']
+        database: ['sqlite', 'postgres', 'mysql']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,11 @@ name: CI
 
 on: [push, pull_request]
 
+env:
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: password
+  POSTGRES_DB: sequelize
+
 jobs:
   build:
 
@@ -11,9 +16,9 @@ jobs:
       postgres:
         image: postgres:12.12
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: sequelize
+          POSTGRES_USER: ${{ env.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ env.POSTGRES_DB }}
         ports:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -363,11 +363,6 @@ export class SequelizeAdapter<
         } as UpdateOptions)
         .catch(errorHandler) as [number, Model[]?];
 
-      if (instances?.length) {
-        // eslint-disable-next-line no-console
-        console.log('instanceof', instances[0] instanceof Model);
-      }
-
       if (sequelizeOptions.returning === false) {
         return []
       }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -358,6 +358,7 @@ export class SequelizeAdapter<
       let [, instances] = await Model
         .update(values, {
           ...sequelizeOptions,
+          raw: false,
           where: { [this.id]: ids.length === 1 ? ids[0] : { [Op.in]: ids } }
         } as UpdateOptions)
         .catch(errorHandler) as [number, Model[]?];

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -362,6 +362,11 @@ export class SequelizeAdapter<
         } as UpdateOptions)
         .catch(errorHandler) as [number, Model[]?];
 
+      if (instances?.length) {
+        // eslint-disable-next-line no-console
+        console.log('instanceof', instances[0] instanceof Model);
+      }
+
       if (sequelizeOptions.returning === false) {
         return []
       }

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -1,6 +1,6 @@
 import { Sequelize } from 'sequelize';
 
-export default (DB?: 'postgres' | 'mysql') => {
+export default (DB?: 'postgres' | 'mysql' | string) => {
   console.log('DB:', DB);
   if (DB === 'postgres') {
     return new Sequelize('sequelize', 'postgres', 'password', {

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -5,11 +5,17 @@ export default (DB?: 'postgres' | 'mysql' | string) => {
   const logging: Options['logging'] = false;
 
   if (DB === 'postgres') {
-    return new Sequelize('sequelize', 'postgres', 'password', {
-      host: 'localhost',
-      dialect: 'postgres',
-      logging
-    });
+    console.log(process.env.POSTGRES_DB, process.env.POSTGRES_USER, process.env.POSTGRES_PASSWORD)
+    return new Sequelize(
+      process.env.POSTGRES_DB ?? 'sequelize',
+      process.env.POSTGRES_USER ?? 'postgres',
+      process.env.POSTGRES_PASSWORD ?? 'password',
+      {
+        host: 'localhost',
+        dialect: 'postgres',
+        logging
+      }
+    );
   } else if (DB === 'mysql') {
     return new Sequelize('sequelize', 'root', '', {
       host: '127.0.0.1',

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -4,6 +4,8 @@ import { Sequelize } from 'sequelize';
 export default (DB?: 'postgres' | 'mysql' | string) => {
   const logging: Options['logging'] = false;
 
+  console.log('DB:', DB);
+
   if (DB === 'postgres') {
     return new Sequelize(
       process.env.POSTGRES_DB ?? 'sequelize',

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -1,22 +1,26 @@
+import type { Options } from 'sequelize';
 import { Sequelize } from 'sequelize';
 
 export default (DB?: 'postgres' | 'mysql' | string) => {
-  console.log('DB:', DB);
+  const logging: Options['logging'] = false;
+
   if (DB === 'postgres') {
     return new Sequelize('sequelize', 'postgres', 'password', {
       host: 'localhost',
-      dialect: 'postgres'
+      dialect: 'postgres',
+      logging
     });
   } else if (DB === 'mysql') {
     return new Sequelize('sequelize', 'root', '', {
       host: '127.0.0.1',
-      dialect: 'mysql'
+      dialect: 'mysql',
+      logging
     });
   } else {
     return new Sequelize('sequelize', '', '', {
       dialect: 'sqlite',
       storage: './db.sqlite',
-      logging: false
+      logging
     });
   }
 };

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -5,7 +5,6 @@ export default (DB?: 'postgres' | 'mysql' | string) => {
   const logging: Options['logging'] = false;
 
   if (DB === 'postgres') {
-    console.log(process.env.POSTGRES_DB, process.env.POSTGRES_USER, process.env.POSTGRES_PASSWORD)
     return new Sequelize(
       process.env.POSTGRES_DB ?? 'sequelize',
       process.env.POSTGRES_USER ?? 'postgres',
@@ -17,11 +16,16 @@ export default (DB?: 'postgres' | 'mysql' | string) => {
       }
     );
   } else if (DB === 'mysql') {
-    return new Sequelize('sequelize', 'root', '', {
-      host: '127.0.0.1',
-      dialect: 'mysql',
-      logging
-    });
+    return new Sequelize(
+      process.env.MYSQl_DATABASE ?? 'sequelize',
+      process.env.MYSQL_USER ?? 'root',
+      process.env.MYSQL_PASSWORD ?? '',
+      {
+        host: '127.0.0.1',
+        dialect: 'mysql',
+        logging
+      }
+    );
   } else {
     return new Sequelize('sequelize', '', '', {
       dialect: 'sqlite',

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -4,8 +4,6 @@ import { Sequelize } from 'sequelize';
 export default (DB?: 'postgres' | 'mysql' | string) => {
   const logging: Options['logging'] = false;
 
-  console.log('DB:', DB);
-
   if (DB === 'postgres') {
     return new Sequelize(
       process.env.POSTGRES_DB ?? 'sequelize',

--- a/test/connection.ts
+++ b/test/connection.ts
@@ -1,6 +1,7 @@
 import { Sequelize } from 'sequelize';
 
 export default (DB?: 'postgres' | 'mysql') => {
+  console.log('DB:', DB);
   if (DB === 'postgres') {
     return new Sequelize('sequelize', 'postgres', 'password', {
       host: 'localhost',

--- a/test/hooks.dehydrate.test.ts
+++ b/test/hooks.dehydrate.test.ts
@@ -4,7 +4,7 @@ import Sequelize from 'sequelize';
 
 import { dehydrate } from '../src/hooks/dehydrate';
 import makeConnection from './connection';
-const sequelize = makeConnection();
+const sequelize = makeConnection(process.env.DB);
 
 type MethodName = 'find' | 'get' | 'create' | 'update' | 'patch' | 'remove';
 

--- a/test/hooks.hydrate.test.ts
+++ b/test/hooks.hydrate.test.ts
@@ -4,7 +4,7 @@ import Sequelize from 'sequelize';
 
 import { hydrate } from '../src/hooks/hydrate';
 import makeConnection from './connection'
-const sequelize = makeConnection();
+const sequelize = makeConnection(process.env.DB);
 
 type MethodName = 'find' | 'get' | 'create' | 'update' | 'patch' | 'remove';
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -89,7 +89,7 @@ const testSuite = adaptertests([
 // https://github.com/sequelize/sequelize/issues/1774
 pg.defaults.parseInt8 = true;
 
-const sequelize = makeConnection();
+const sequelize = makeConnection(process.env.DB);
 
 const Model = sequelize.define('people', {
   name: {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,18 +25,19 @@ const testSuite = adaptertests([
   '.get',
   '.get + $select',
   '.get + id + query',
-  '.get + NotFound',
+  // '.get + NotFound', // add '.get + NotFound (integer)' once https://github.com/feathersjs/feathers/pull/3486 is merged and published
   '.find',
   '.remove',
   '.remove + $select',
   '.remove + id + query',
+  // add '.remove + NotFound (integer)' once https://github.com/feathersjs/feathers/pull/3486 is merged and published
   '.remove + multi',
   '.remove + multi no pagination',
   '.update',
   '.update + $select',
   '.update + id + query',
   '.update + query + NotFound',
-  '.update + NotFound',
+  // '.update + NotFound', // add '.update + NotFound (integer)' once https://github.com/feathersjs/feathers/pull/3486 is merged and published
   '.patch',
   '.patch + $select',
   '.patch + id + query',
@@ -45,7 +46,7 @@ const testSuite = adaptertests([
   '.patch multi query same',
   '.patch multi query changed',
   '.patch + query + NotFound',
-  '.patch + NotFound',
+  // '.patch + NotFound', // add '.patch + NotFound (integer)' once https://github.com/feathersjs/feathers/pull/3486 is merged and published
   '.create',
   '.create + $select',
   '.create multi',
@@ -228,6 +229,89 @@ describe('Feathers Sequelize Service', () => {
 
     testSuite(app, errors, 'people', 'id');
     testSuite(app, errors, 'people-customid', 'customid');
+
+    describe('remove this when https://github.com/feathersjs/feathers/pull/3486 is merged and published', () => {
+      it('.get + NotFound (integer)', async () => {
+        try {
+          await app.service('people').get(123456789)
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      });
+
+      it('.get + NotFound (integer)', async () => {
+        try {
+          await app.service('people-customid').get(123456789)
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      });
+
+      it('.remove + NotFound (integer)', async () => {
+        try {
+          await app.service('people').remove(123456789)
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      })
+
+      it('.remove + NotFound (integer)', async () => {
+        try {
+          await app.service('people-customid').remove(123456789)
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      })
+
+      it('.update + NotFound (integer)', async () => {
+        try {
+          await app.service('people').update(123456789, {
+            name: 'NotFound'
+          })
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      })
+
+      it('.update + NotFound (integer)', async () => {
+        try {
+          await app.service('people-customid').update(123456789, {
+            name: 'NotFound'
+          })
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      })
+
+      it('.patch + NotFound (integer)', async () => {
+        try {
+          await app.service('people').patch(123456789, {
+            name: 'PatchDoug'
+          })
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      })
+
+      it('.patch + NotFound (integer)', async () => {
+        try {
+          await app.service('people-customid').patch(123456789, {
+            name: 'PatchDoug'
+          })
+          throw new Error('Should never get here')
+        } catch (error: any) {
+          assert.strictEqual(error.name, 'NotFound', 'Error is a NotFound Feathers error')
+        }
+      })
+    });
+
   });
 
   describe('Feathers-Sequelize Specific Tests', () => {


### PR DESCRIPTION
This PR adds ci tests for postgres & mysql. It also fixes a bug for postgres multi patch.

Also tests from `@feathersjs/adapter-tests` were excluded for `NotFound` tests since they are tested with string, not integer values. Added the tests explicitely here and opened https://github.com/feathersjs/feathers/pull/3486.