### PR TITLE
Remove `ModelWithScope` and add `handleError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A [Feathers](https://feathersjs.com) database adapter for [Sequelize](http://seq
   - [`service(options)`](#serviceoptions)
   - [params.sequelize](#paramssequelize)
   - [operators](#operatormap)
+  - [Modifying the model](#modifyModel)
 - [Caveats](#caveats)
   - [Sequelize `raw` queries](#sequelize-raw-queries)
   - [Working with MSSQL](#working-with-mssql)
@@ -152,6 +153,27 @@ app.service('users').find({
 
 ```
 GET /users?name[$like]=Dav%
+```
+
+## Modifying the Model
+
+Sequelize allows you to call methods like `Model.scope()`, `Model.schema()`, and others. To use these methods, extend the class to overwrite the `getModel` method.
+
+```js
+const { SequelizeService } = require('feathers-sequelize');
+
+class Service extends SequelizeService {
+  getModel(params) {
+    let Model = this.options.Model;
+    if(params?.sequelize?.scope) {
+      Model = Model.scope(params?.sequelize?.scope);
+    }
+    if(params?.sequelize?.schema) {
+      Model = Model.schema(params?.sequelize?.schema);
+    }
+    return Model;
+  }
+}
 ```
 
 ## Caveats

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ class Service extends SequelizeService {
   getModel(params) {
     let Model = this.options.Model;
     if (params?.sequelize?.scope) {
-      Model = Model.scope(params?.sequelize?.scope);
+      Model = Model.scope(params.sequelize.scope);
     }
     if (params?.sequelize?.schema) {
-      Model = Model.schema(params?.sequelize?.schema);
+      Model = Model.schema(params.sequelize.schema);
     }
     return Model;
   }

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ const { SequelizeService } = require('feathers-sequelize');
 class Service extends SequelizeService {
   getModel(params) {
     let Model = this.options.Model;
-    if(params?.sequelize?.scope) {
+    if (params?.sequelize?.scope) {
       Model = Model.scope(params?.sequelize?.scope);
     }
-    if(params?.sequelize?.schema) {
+    if (params?.sequelize?.schema) {
       Model = Model.schema(params?.sequelize?.schema);
     }
     return Model;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -111,16 +111,9 @@ export class SequelizeAdapter<
       throw new Error('getModel was called without a Model present in the constructor options and without overriding getModel! Perhaps you intended to override getModel in a child class?');
     }
 
-    return this.options.Model;
+    return this.options.Model
   }
 
-  ModelWithScope (params: ServiceParams) {
-    const Model = this.getModel(params);
-    if (params?.sequelize?.scope) {
-      return Model.scope(params.sequelize.scope);
-    }
-    return Model;
-  }
 
   convertOperators (q: any): Query {
     if (Array.isArray(q)) {
@@ -226,7 +219,7 @@ export class SequelizeAdapter<
   async _find (params?: ServiceParams & { paginate: false }): Promise<Result[]>
   async _find (params?: ServiceParams): Promise<Paginated<Result> | Result[]>
   async _find (params: ServiceParams = {} as ServiceParams): Promise<Paginated<Result> | Result[]> {
-    const Model = this.ModelWithScope(params);
+    const Model = this.getModel(params);
     const { paginate } = this.filterQuery(params);
     const sequelizeOptions = this.paramsToAdapter(null, params);
 
@@ -259,7 +252,7 @@ export class SequelizeAdapter<
   }
 
   async _get (id: Id, params: ServiceParams = {} as ServiceParams): Promise<Result> {
-    const Model = this.ModelWithScope(params);
+    const Model = this.getModel(params);
     const sequelizeOptions = this.paramsToAdapter(id, params);
     const result = await Model.findAll(sequelizeOptions).catch(errorHandler);
     if (result.length === 0) {
@@ -283,7 +276,7 @@ export class SequelizeAdapter<
       return []
     }
 
-    const Model = this.ModelWithScope(params);
+    const Model = this.getModel(params);
     const sequelizeOptions = this.paramsToAdapter(null, params);
 
     if (isArray) {
@@ -334,7 +327,7 @@ export class SequelizeAdapter<
       throw new MethodNotAllowed('Can not patch multiple entries')
     }
 
-    const Model = this.ModelWithScope(params);
+    const Model = this.getModel(params);
     const sequelizeOptions = this.paramsToAdapter(id, params);
     const select = selector(params, this.id);
     const values = _.omit(data, this.id);
@@ -462,7 +455,7 @@ export class SequelizeAdapter<
   }
 
   async _update (id: Id, data: Data, params: ServiceParams = {} as ServiceParams): Promise<Result> {
-    const Model = this.ModelWithScope(params);
+    const Model = this.getModel(params);
     const sequelizeOptions = this.paramsToAdapter(id, params);
     const select = selector(params, this.id);
 
@@ -516,7 +509,7 @@ export class SequelizeAdapter<
       throw new MethodNotAllowed('Can not remove multiple entries')
     }
 
-    const Model = this.ModelWithScope(params);
+    const Model = this.getModel(params);
     const sequelizeOptions = this.paramsToAdapter(id, params);
 
     if (id === null) {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -111,7 +111,7 @@ export class SequelizeAdapter<
       throw new Error('getModel was called without a Model present in the constructor options and without overriding getModel! Perhaps you intended to override getModel in a child class?');
     }
 
-    return this.options.Model
+    return this.options.Model;
   }
 
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -111,19 +111,7 @@ const Model = sequelize.define('people', {
     defaultValue: 'pending'
   }
 }, {
-  freezeTableName: true,
-  scopes: {
-    active: {
-      where: {
-        status: 'active'
-      }
-    },
-    pending: {
-      where: {
-        status: 'pending'
-      }
-    }
-  }
+  freezeTableName: true
 });
 const Order = sequelize.define('orders', {
   name: {
@@ -779,20 +767,6 @@ describe('Feathers Sequelize Service', () => {
           assert.strictEqual(error.message, 'Invalid query parameter $invalidOp');
         }
       });
-    });
-
-    it('can set the scope of an operation #130', async () => {
-      const people = app.service('people');
-      const data = { name: 'Active', status: 'active' };
-      const SCOPE_TO_ACTIVE = { sequelize: { scope: 'active' } };
-      const SCOPE_TO_PENDING = { sequelize: { scope: 'pending' } };
-      await people.create(data);
-
-      const staPeople = await people.find(SCOPE_TO_ACTIVE) as Paginated<any>;
-      assert.strictEqual(staPeople.data.length, 1);
-
-      const stpPeople = await people.find(SCOPE_TO_PENDING) as Paginated<any>;
-      assert.strictEqual(stpPeople.data.length, 0);
     });
   });
 


### PR DESCRIPTION
This PR extends the class to have a `handleError` function that will make it easier for the user to handle errors from the service. It also removes `ModelWithScope` in favor of `getModel`. The `params.sequelize.scope` feature was never really documented. I have updated the README to reflect how to regain this functionality and more.

Closes
#433 
#449 